### PR TITLE
x_track: use nuttx_deinit to free all resources for x_track.

### DIFF
--- a/x_track/x_track_main.cpp
+++ b/x_track/x_track_main.cpp
@@ -96,7 +96,7 @@ extern "C" int main(int argc, const char* argv[])
     /* Clean up */
     lv_timer_delete(app_timer);
     App_DestroyContext(appCtx);
-    lv_display_delete(result.disp);
+    lv_nuttx_deinit(&result);
     lv_deinit();
     return 0;
 }


### PR DESCRIPTION
use nuttx_deinit to free all resources for x_track.