### PR TITLE
修复README文件中的404链接问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ This repository implements examples of openvela native application code. Develop
 
 ## Usage Instructions  
 
-- [Music Player](../../../docs/blob/dev/en/demo/Music_Player_Example.md)  
-- [Smart Band](../../../docs/blob/dev/en/demo/Smart_Band_Example.md)  
-- [Bicycle Computer](../../../docs/blob/dev/en/demo/X_Track.md)
+- [Music Player](music_player/)  
+- [Smart Band](bandx/)  
+- [Bicycle Computer](x_track/)
 - [Calculator](calculator/Readme.md)
 - [Relation Calculator](relation_calculator/Readme.md)
-- [Whackmole](Whackmole/Readme.md)
+- [Whackmole](Whackmole/README.md)

--- a/README_zh-cn.md
+++ b/README_zh-cn.md
@@ -8,9 +8,9 @@
 
 ## 使用说明
 
-- [音乐播放器](../../../docs/blob/dev/zh-cn/demo/Music_Player_Example_zh-cn.md)
-- [智能手环](../../../docs/blob/dev/zh-cn/demo/Smart_Band_Example_zh-cn.md)
-- [自行车码表](../../../docs/blob/dev/zh-cn/demo/X_Track_zh-cn.md)
+- [音乐播放器](music_player/)
+- [智能手环](bandx/)
+- [自行车码表](x_track/)
 - [计算器](calculator/Readme.md)
-- [亲戚计算器](relation_calculator/Readme.md)
-- [打地鼠](Whackmole/Readme.md)
+- [亲戚计算器](relation_calculator/Readme_zh-cn.md)
+- [打地鼠](Whackmole/README_zh-cn.md)


### PR DESCRIPTION
## 修复内容

修复了 README.md 和 README_zh-cn.md 中指向404错误的链接：

### 英文版 (README.md)
- **Music Player**：指向 `music_player/` 目录
- **Smart Band**：指向 `bandx/` 目录  
- **Bicycle Computer**：指向 `x_track/` 目录
- 修正 **Whackmole** 链接文件名大小写

### 中文版 (README_zh-cn.md)
- **Music Player**：指向 `music_player/` 目录
- **Smart Band**：指向 `bandx/` 目录
- **Bicycle Computer**：指向 `x_track/` 目录
- **Relation Calculator**：指向中文版文档
- **Whackmole**：指向中文版文档