### PR TITLE
fix: remove-ff 

### DIFF
--- a/music_player2/audio_ctl.c
+++ b/music_player2/audio_ctl.c
@@ -356,7 +356,6 @@ int audio_ctl_seek(audioctl_s* ctl, unsigned ms) {
         ctl->current_position_ms = ms;
         AUDIO_LOG("Simulation position update successful: %lu ms",
             (unsigned long)ms);
-        FF
     } else {
         AUDIO_LOG("Seek position exceeds file length: %lu ms > %lu ms",
             (unsigned long)ms, (unsigned long)ctl->total_duration_ms);


### PR DESCRIPTION
 Remove the redundant FF characters in the audio_ctl_seek function
- Removed the wrongly-written characters in line 359
- This does not affect other functions