### PR TITLE
calculator: fix the compile error

### DIFF
--- a/calculator/CMakeLists.txt
+++ b/calculator/CMakeLists.txt
@@ -24,6 +24,15 @@ if(CONFIG_LVX_USE_DEMO_CALCULATOR)
   set(STACKSIZE 32768)
   set(MODULE ${CONFIG_LVX_USE_DEMO_CALCULATOR})
   set(CXXEXT .cpp)
+  set(CSRCS
+      res/fonts/size_16_normal.c
+      res/fonts/size_22_bold.c
+      res/fonts/size_24_normal.c
+      res/fonts/size_28_normal.c
+      res/fonts/size_48_normal.c
+      res/fonts/size_60_bold.c
+      res/icons/background.c 
+  )
   set(CXXSRCS
       calculator_cre.cpp
       expression_calc.cpp
@@ -35,6 +44,6 @@ if(CONFIG_LVX_USE_DEMO_CALCULATOR)
     PRIORITY ${PRIORITY}
     STACKSIZE ${STACKSIZE}
     MODULE ${MODULE}
-    SRCS ${MAINSRC} ${CXXSRCS}
+    SRCS ${MAINSRC} ${CXXSRCS} ${CSRCS}
   )
 endif()


### PR DESCRIPTION
apps/packages/demos/calculator/libapps_calculator.a: in function `Resource::load_resources()':
apps/packages/demos/calculator/calculator_cre.h:76: undefined reference to `size_22_bold'
undefined reference to `size_48_normal'
undefined reference to `size_24_normal'

*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*

