### PR TITLE
demos/mimo: add Xiaomi MiMo AI provider demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This repository implements examples of openvela native application code. Develop
 - [Breakout Game](breakout/Readme.md)
 - [Calculator](calculator/Readme.md)
 - [Hourglass](hourglass/Readme.md)
+- [MiMo AI Provider](mimo/README.md)
 - [Music Player](../../../docs/blob/dev/en/demo/Music_Player_Example.md)
 - [Music Player 2](music_player2/README-en.md)
 - [Relation Calculator](relation_calculator/Readme.md)

--- a/README_zh-cn.md
+++ b/README_zh-cn.md
@@ -18,5 +18,6 @@
 - [打砖块](breakout/Readme.md)
 - [电子沙漏](hourglass/Readme.md)
 - [贪吃蛇](snake_game/Readme.md)
+- [MiMo AI 大模型接入](mimo/README_zh-cn.md)
 - [虚拟宠物](pet/README.md)
 - [电子木鱼](wooden_fish/README_zh-cn.md)

--- a/mimo/CMakeLists.txt
+++ b/mimo/CMakeLists.txt
@@ -1,0 +1,40 @@
+# ##############################################################################
+# packages/demos/mimo/CMakeLists.txt
+#
+# Copyright (C) 2024 Xiaomi Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# ##############################################################################
+
+if(CONFIG_DEMOS_MIMO)
+  set(PROGNAME mimo)
+  set(PRIORITY ${CONFIG_MIMO_PRIORITY})
+  set(STACKSIZE ${CONFIG_MIMO_STACKSIZE})
+  set(MODULE ${CONFIG_DEMOS_MIMO})
+  set(MAINSRC mimo_main.c)
+
+  set(CSRCS
+    mimo_provider.c
+    mimo_agent.c
+  )
+
+  nuttx_add_application(
+    NAME ${PROGNAME}
+    PRIORITY ${PRIORITY}
+    STACKSIZE ${STACKSIZE}
+    MODULE ${MODULE}
+    INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}
+    SRCS ${MAINSRC} ${CSRCS}
+  )
+endif()

--- a/mimo/Kconfig
+++ b/mimo/Kconfig
@@ -1,0 +1,87 @@
+#
+# Copyright (C) 2024 Xiaomi Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+menuconfig DEMOS_MIMO
+	tristate "Xiaomi MiMo AI Provider"
+	default n
+	depends on NETUTILS_CJSON
+	select NETUTILS_WEBCLIENT
+	select CRYPTO_MBEDTLS
+	---help---
+		Xiaomi MiMo AI model provider for openvela/NuttX.
+		Provides a standalone CLI demo that calls the MiMo
+		chat completions API with thinking mode support.
+
+		API: https://api.xiaomimimo.com/v1/chat/completions
+		Model: mimo-v2-flash (309B/15B MoE, 262K context)
+
+if DEMOS_MIMO
+
+config MIMO_API_KEY
+	string "Xiaomi MiMo API Key"
+	default ""
+	---help---
+		API key from https://platform.xiaomimimo.com/
+
+config MIMO_MODEL
+	string "Model Name"
+	default "mimo-v2-flash"
+	---help---
+		MiMo model identifier.
+
+config MIMO_API_BASE_URL
+	string "API Base URL"
+	default "https://api.xiaomimimo.com/v1/chat/completions"
+	---help---
+		MiMo chat completions endpoint.
+
+config MIMO_TEMPERATURE
+	int "Temperature x100"
+	default 80
+	---help---
+		Temperature * 100. Recommended: 80 for general,
+		30 for agentic/tool-use tasks.
+
+config MIMO_ENABLE_THINKING
+	bool "Enable thinking mode"
+	default y
+	---help---
+		Enable MiMo extended thinking/reasoning mode.
+		The model returns reasoning_content alongside
+		regular content for deeper chain-of-thought.
+
+config MIMO_ENABLE_TOOLS
+	bool "Enable tool calling"
+	default y
+	---help---
+		Enable OpenAI-compatible function calling / tools.
+
+config MIMO_PRIORITY
+	int "Task priority"
+	default 100
+
+config MIMO_STACKSIZE
+	int "Stack size"
+	default 32768
+	---help---
+		Stack size (32KB recommended for TLS/HTTPS)
+
+endif # DEMOS_MIMO

--- a/mimo/Make.defs
+++ b/mimo/Make.defs
@@ -1,0 +1,22 @@
+############################################################################
+# packages/demos/mimo/Make.defs
+#
+# Copyright (C) 2024 Xiaomi Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_DEMOS_MIMO),)
+CONFIGURED_APPS += $(APPDIR)/packages/demos/mimo
+endif

--- a/mimo/Makefile
+++ b/mimo/Makefile
@@ -1,0 +1,37 @@
+############################################################################
+# packages/demos/mimo/Makefile
+#
+# Copyright (C) 2024 Xiaomi Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+ifeq ($(CONFIG_DEMOS_MIMO), y)
+PROGNAME  = mimo
+PRIORITY  = $(CONFIG_MIMO_PRIORITY)
+STACKSIZE = $(CONFIG_MIMO_STACKSIZE)
+MODULE    = $(CONFIG_DEMOS_MIMO)
+
+CSRCS  = mimo_provider.c
+CSRCS += mimo_agent.c
+
+MAINSRC = mimo_main.c
+
+CFLAGS += ${INCDIR_PREFIX}$(APPDIR)/packages/demos/mimo
+
+endif
+
+include $(APPDIR)/Application.mk

--- a/mimo/README.md
+++ b/mimo/README.md
@@ -1,0 +1,157 @@
+# MiMo - Xiaomi AI Model Provider for openvela/NuttX
+
+A standalone Xiaomi MiMo large language model provider for embedded systems, built on the openvela/NuttX platform with full HTTPS + TLS support for on-device cloud inference.
+
+English | [中文](README_zh-cn.md)
+
+## Features
+
+- OpenAI-compatible Chat Completions API
+- Thinking mode (reasoning_content) for chain-of-thought reasoning
+- Function calling / tool use support
+- Interactive REPL and single-shot CLI modes
+- Secure HTTPS communication via mbedTLS
+- Automatic conversation history management with multi-turn support
+
+## Model
+
+**mimo-v2-flash**: 309B total / 15B active parameters (MoE architecture), 262K context window, hybrid attention.
+
+- Endpoint: `https://api.xiaomimimo.com/v1/chat/completions`
+- Auth: `Bearer <API_KEY>`
+- Get your key at: https://platform.xiaomimimo.com/
+
+## Project Structure
+
+```
+packages/demos/mimo/
+├── mimo.h             # Core data structures and API definitions
+├── mimo_main.c        # Entry point, CLI interaction logic
+├── mimo_agent.c       # Agent layer: conversation history & tool dispatch
+├── mimo_provider.c    # Provider layer: HTTP/TLS communication & JSON handling
+├── Kconfig            # NuttX menu configuration
+├── CMakeLists.txt     # CMake build script
+├── Makefile           # Make build script
+└── Make.defs          # NuttX application registration
+```
+
+## Build & Run (Emulator Example)
+
+The following example uses the openvela `goldfish-armeabi-v7a-ap` emulator target.
+
+### 1. Configure
+
+Enable `DEMOS_MIMO` in menuconfig and set your API key:
+
+```bash
+./build.sh vendor/openvela/boards/vela/configs/goldfish-armeabi-v7a-ap/ menuconfig
+# Navigate to: Application Configuration → Demos → Xiaomi MiMo AI Provider
+# Enable and set API key
+```
+
+After saving menuconfig, the following configs will be added to `vendor/openvela/boards/vela/configs/goldfish-armeabi-v7a-ap/defconfig`:
+
+```
+CONFIG_DEMOS_MIMO=y
+CONFIG_MIMO_API_KEY="your_api_key_here"
+```
+
+### Configuration Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `MIMO_API_KEY` | "" | API key from platform.xiaomimimo.com |
+| `MIMO_MODEL` | mimo-v2-flash | Model identifier |
+| `MIMO_API_BASE_URL` | https://api.xiaomimimo.com/v1/chat/completions | API endpoint |
+| `MIMO_TEMPERATURE` | 80 | Temperature x100 (80 = 0.8) |
+| `MIMO_ENABLE_THINKING` | y | Enable chain-of-thought reasoning mode |
+| `MIMO_ENABLE_TOOLS` | y | Enable function calling |
+| `MIMO_STACKSIZE` | 32768 | Task stack size (32KB recommended for TLS) |
+
+### 2. Build
+
+```bash
+./build.sh vendor/openvela/boards/vela/configs/goldfish-armeabi-v7a-ap -j8
+```
+
+### 3. Start Emulator
+
+```bash
+./emulator.sh vela -no-windows
+```
+
+### 4. Run in NSH
+
+```bash
+# Bring up network interface
+openvela-ap> ifup eth0
+ifup eth0...OK
+
+# Obtain IP address via DHCP
+openvela-ap> renew eth0
+
+# Launch MiMo (interactive mode)
+openvela-ap> mimo
+
+# Or single-shot mode
+openvela-ap> mimo What is the capital of France?
+```
+
+### Example Session
+
+```
+openvela-ap> mimo
+[mimo] Provider initialized
+[mimo] Endpoint: https://api.xiaomimimo.com/v1/chat/completions
+[mimo] Thinking mode: enabled
+[mimo:agent] Initialized (max_turns=10, max_history=32)
+
+  MiMo - Xiaomi AI Assistant
+  Model: mimo-v2-flash
+  Thinking: on
+  Type 'quit' to exit.
+
+You> who are you
+[mimo] POST https://api.xiaomimimo.com/v1/chat/completions (2318 bytes)
+[mimo] TLS connecting to api.xiaomimimo.com:443
+[mimo] Connecting to api.xiaomimimo.com (120.133.85.111:443)
+[mimo] TCP connected, starting TLS handshake
+[mimo] TLS handshake complete
+[mimo] HTTP 200, response 1815 bytes
+[mimo] Thinking: 好的，用户现在问"who are you"，这是英语版本的"你是谁"...
+MiMo> I am MiMo, an AI assistant developed by the Xiaomi LLM Core Team.
+      I'm here to help with information queries, problem-solving,
+      content creation, logical reasoning, and more.
+      How can I assist you today? 😊
+
+You>
+```
+
+Type `quit` or `exit` to leave interactive mode.
+
+## Architecture
+
+```
+User Input → mimo_main → mimo_agent_chat → mimo_provider_chat → MiMo API
+                              ↑                    ↓
+                      Conversation History    HTTP/TLS Communication
+                      Tool Dispatch Loop      JSON Request Building
+                        (ReAct Loop)          Response Parsing
+```
+
+- **Provider Layer** (`mimo_provider.c`): Handles HTTP POST requests, TLS handshake, JSON request body construction, and response parsing. Uses NuttX webclient + mbedTLS for HTTPS.
+- **Agent Layer** (`mimo_agent.c`): Manages conversation history (up to 32 messages with auto-compaction), implements a ReAct tool-calling loop (up to 10 turns), and preserves `reasoning_content` across multi-turn tool calls in thinking mode.
+- **Main Layer** (`mimo_main.c`): CLI entry point supporting both interactive and single-shot modes.
+
+## Recommended Sampling Parameters
+
+Per Xiaomi's documentation:
+- `top_p=0.95` (hardcoded)
+- `temperature=0.8`: math, writing, web development
+- `temperature=0.3`: agentic tasks (tool use)
+
+## Dependencies
+
+- `NETUTILS_CJSON`: JSON parsing
+- `NETUTILS_WEBCLIENT`: HTTP client
+- `CRYPTO_MBEDTLS`: TLS encryption

--- a/mimo/README_zh-cn.md
+++ b/mimo/README_zh-cn.md
@@ -1,0 +1,156 @@
+# MiMo - 小米 AI 大模型接入组件（openvela/NuttX）
+
+面向嵌入式系统的小米 MiMo 大模型接入组件，基于 openvela/NuttX 平台，提供完整的 HTTPS + TLS 通信能力，可直接在设备端调用 MiMo 云端推理服务。
+
+[English](README.md) | 中文
+
+## 功能特性
+
+- 兼容 OpenAI Chat Completions API 协议
+- 支持 MiMo 思维链模式（reasoning_content），输出推理过程
+- 支持 Function Calling / 工具调用
+- 交互式 REPL 和单次命令行两种运行模式
+- 基于 mbedTLS 的 HTTPS 安全通信
+- 自动管理对话历史，支持多轮对话
+
+## 模型信息
+
+**mimo-v2-flash**：总参数 309B / 激活参数 15B（MoE 混合专家架构），262K 上下文窗口，混合注意力机制。
+
+- API 地址：`https://api.xiaomimimo.com/v1/chat/completions`
+- 认证方式：`Bearer <API_KEY>`
+- 申请密钥：https://platform.xiaomimimo.com/
+
+## 项目结构
+
+```
+packages/demos/mimo/
+├── mimo.h             # 核心数据结构与接口定义
+├── mimo_main.c        # 主入口，CLI 交互逻辑
+├── mimo_agent.c       # Agent 层，管理对话历史与工具调度
+├── mimo_provider.c    # Provider 层，HTTP/TLS 通信与 JSON 协议处理
+├── Kconfig            # NuttX 菜单配置
+├── CMakeLists.txt     # CMake 构建脚本
+├── Makefile           # Make 构建脚本
+└── Make.defs          # NuttX 应用注册
+```
+
+## 编译与运行（模拟器示例）
+
+以下以 openvela `goldfish-armeabi-v7a-ap` 模拟器为例。
+
+### 1. 配置
+
+在 menuconfig 中启用 `DEMOS_MIMO` 并设置 API Key：
+
+```bash
+./build.sh vendor/openvela/boards/vela/configs/goldfish-armeabi-v7a-ap/ menuconfig
+# 找到 Application Configuration → Demos → Xiaomi MiMo AI Provider
+# 启用后设置 API Key
+```
+
+保存 menuconfig 后，`vendor/openvela/boards/vela/configs/goldfish-armeabi-v7a-ap/defconfig` 中将增加以下配置：
+
+```
+CONFIG_DEMOS_MIMO=y
+CONFIG_MIMO_API_KEY="your_api_key_here"
+```
+
+### 配置项说明
+
+| 配置项 | 默认值 | 说明 |
+|--------|--------|------|
+| `MIMO_API_KEY` | "" | MiMo 平台 API 密钥 |
+| `MIMO_MODEL` | mimo-v2-flash | 模型标识 |
+| `MIMO_API_BASE_URL` | https://api.xiaomimimo.com/v1/chat/completions | API 端点 |
+| `MIMO_TEMPERATURE` | 80 | 温度参数 ×100（80 即 0.8） |
+| `MIMO_ENABLE_THINKING` | y | 启用思维链推理模式 |
+| `MIMO_ENABLE_TOOLS` | y | 启用工具调用 |
+| `MIMO_STACKSIZE` | 32768 | 任务栈大小（TLS 需要较大栈空间） |
+
+### 2. 编译
+
+```bash
+./build.sh vendor/openvela/boards/vela/configs/goldfish-armeabi-v7a-ap -j8
+```
+
+### 3. 启动模拟器
+
+```bash
+./emulator.sh vela -no-windows
+```
+
+### 4. 在 NSH 中运行
+
+```bash
+# 启动网卡
+openvela-ap> ifup eth0
+ifup eth0...OK
+
+# 通过 DHCP 获取 IP 地址
+openvela-ap> renew eth0
+
+# 启动 MiMo（交互模式）
+openvela-ap> mimo
+
+# 或单次问答模式
+openvela-ap> mimo 法国的首都是哪里？
+```
+
+### 运行示例
+
+```
+openvela-ap> mimo
+[mimo] Provider initialized
+[mimo] Endpoint: https://api.xiaomimimo.com/v1/chat/completions
+[mimo] Thinking mode: enabled
+[mimo:agent] Initialized (max_turns=10, max_history=32)
+
+  MiMo - Xiaomi AI Assistant
+  Model: mimo-v2-flash
+  Thinking: on
+  Type 'quit' to exit.
+
+You> 你是谁
+[mimo] POST https://api.xiaomimimo.com/v1/chat/completions (295 bytes)
+[mimo] TLS connecting to api.xiaomimimo.com:443
+[mimo] Connecting to api.xiaomimimo.com (120.133.85.111:443)
+[mimo] TCP connected, starting TLS handshake
+[mimo] TLS handshake complete
+[mimo] HTTP 200, response 1433 bytes
+[mimo] Thinking: 好的，用户直接问"你是谁"，我需要先确认这是中文的自...
+MiMo> 你好！我是MiMo，由小米大模型Core团队开发的AI助手。
+      我旨在为用户提供信息查询、问题解答、内容创作、逻辑推理等帮助。
+      如果你有任何问题或需要协助，随时告诉我！
+
+You>
+```
+
+交互模式下输入 `quit` 或 `exit` 退出。
+
+## 架构设计
+
+```
+用户输入 → mimo_main → mimo_agent_chat → mimo_provider_chat → MiMo API
+                            ↑                    ↓
+                        对话历史管理          HTTP/TLS 通信
+                        工具调度循环          JSON 请求构建
+                        (ReAct Loop)         响应解析
+```
+
+- **Provider 层**（`mimo_provider.c`）：负责 HTTP POST 请求、TLS 握手、JSON 请求体构建和响应解析。使用 NuttX webclient + mbedTLS 实现 HTTPS 通信。
+- **Agent 层**（`mimo_agent.c`）：维护对话历史（最多 32 条，自动压缩），实现 ReAct 工具调用循环（最多 10 轮），在思维链模式下保留 `reasoning_content` 用于多轮传递。
+- **Main 层**（`mimo_main.c`）：CLI 入口，支持交互式和单次两种模式。
+
+## 推荐采样参数
+
+根据小米官方文档：
+- `top_p=0.95`（代码中已固定）
+- `temperature=0.8`：适用于数学、写作、Web 开发等场景
+- `temperature=0.3`：适用于 Agent / 工具调用场景
+
+## 依赖
+
+- `NETUTILS_CJSON`：JSON 解析
+- `NETUTILS_WEBCLIENT`：HTTP 客户端
+- `CRYPTO_MBEDTLS`：TLS 加密通信

--- a/mimo/mimo.h
+++ b/mimo/mimo.h
@@ -1,0 +1,110 @@
+/****************************************************************************
+ * packages/demos/mimo/mimo.h
+ *
+ * Copyright (C) 2024 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __DEMOS_MIMO_H
+#define __DEMOS_MIMO_H
+
+#include <nuttx/config.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define MIMO_MAX_MESSAGES     32
+#define MIMO_MAX_RESPONSE     (32 * 1024)
+#define MIMO_MAX_TOOL_RESULT  (8 * 1024)
+#define MIMO_MAX_URL_LEN      256
+#define MIMO_MAX_TOOLS        16
+
+/* Configuration from Kconfig */
+
+#define MIMO_API_KEY       CONFIG_MIMO_API_KEY
+#define MIMO_MODEL         CONFIG_MIMO_MODEL
+#define MIMO_API_BASE_URL  CONFIG_MIMO_API_BASE_URL
+#define MIMO_TEMPERATURE   CONFIG_MIMO_TEMPERATURE
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/* Message roles */
+
+enum mimo_role_e
+{
+  MIMO_ROLE_SYSTEM = 0,
+  MIMO_ROLE_USER,
+  MIMO_ROLE_ASSISTANT,
+  MIMO_ROLE_TOOL
+};
+
+/* A single message in conversation */
+
+struct mimo_message_s
+{
+  enum mimo_role_e  role;
+  char             *content;            /* Heap-allocated text */
+  char             *tool_call_id;       /* Non-NULL if role == TOOL */
+  char             *tool_name;          /* Non-NULL if assistant requested tool */
+  char             *reasoning_content;  /* Thinking mode reasoning (may be NULL) */
+};
+
+/* Chat completion request */
+
+struct mimo_chat_req_s
+{
+  const char            *model;
+  const char            *system_prompt;
+  struct mimo_message_s *messages;
+  int                    message_count;
+  const char            *tools_json;   /* JSON array of tool schemas, or NULL */
+  int                    temperature;  /* x100, e.g. 80 = 0.8 */
+};
+
+/* Chat completion response */
+
+struct mimo_chat_resp_s
+{
+  char *content;            /* Assistant text (heap-allocated) */
+  char *tool_call_id;       /* Non-NULL if tool_use stop reason */
+  char *tool_name;          /* Tool name to invoke */
+  char *tool_input;         /* Tool input JSON string */
+  char *reasoning_content;  /* Thinking mode reasoning (heap-allocated) */
+  bool  is_tool_use;        /* true if the model wants to call a tool */
+};
+
+/****************************************************************************
+ * Public Function Prototypes - Provider
+ ****************************************************************************/
+
+int  mimo_provider_init(const char *api_key, const char *base_url);
+int  mimo_provider_chat(const struct mimo_chat_req_s *req,
+                        struct mimo_chat_resp_s *resp);
+void mimo_chat_resp_free(struct mimo_chat_resp_s *resp);
+void mimo_provider_destroy(void);
+
+/****************************************************************************
+ * Public Function Prototypes - Agent
+ ****************************************************************************/
+
+int  mimo_agent_init(void);
+int  mimo_agent_chat(const char *user_input, char **response);
+
+#endif /* __DEMOS_MIMO_H */

--- a/mimo/mimo_agent.c
+++ b/mimo/mimo_agent.c
@@ -1,0 +1,189 @@
+/****************************************************************************
+ * packages/demos/mimo/mimo_agent.c
+ *
+ * Copyright (C) 2024 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "mimo.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define AGENT_MAX_TURNS  10
+
+/* MiMo recommended system prompts */
+
+#define MIMO_SYSTEM_PROMPT_EN \
+  "You are MiMo, an AI assistant developed by Xiaomi. " \
+  "You are helpful, concise, and efficient."
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static struct mimo_message_s g_history[MIMO_MAX_MESSAGES];
+static int g_history_count = 0;
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static void history_free_entry(struct mimo_message_s *m)
+{
+  free(m->content);
+  free(m->tool_call_id);
+  free(m->tool_name);
+  free(m->reasoning_content);
+  m->content = NULL;
+  m->tool_call_id = NULL;
+  m->tool_name = NULL;
+  m->reasoning_content = NULL;
+}
+
+static void history_compact(void)
+{
+  int keep = MIMO_MAX_MESSAGES / 2;
+  int drop = g_history_count - keep;
+  int i;
+
+  for (i = 0; i < drop; i++)
+    {
+      history_free_entry(&g_history[i]);
+    }
+
+  memmove(g_history, g_history + drop,
+          keep * sizeof(struct mimo_message_s));
+  g_history_count = keep;
+
+  printf("[mimo:agent] Compacted history to %d messages\n", keep);
+}
+
+static void history_add(enum mimo_role_e role, const char *content,
+                        const char *tool_call_id,
+                        const char *reasoning_content)
+{
+  if (g_history_count >= MIMO_MAX_MESSAGES)
+    {
+      history_compact();
+    }
+
+  struct mimo_message_s *m = &g_history[g_history_count++];
+  m->role = role;
+  m->content = content ? strdup(content) : NULL;
+  m->tool_call_id = tool_call_id ? strdup(tool_call_id) : NULL;
+  m->tool_name = NULL;
+  m->reasoning_content = reasoning_content ? strdup(reasoning_content)
+                                           : NULL;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int mimo_agent_init(void)
+{
+  g_history_count = 0;
+  printf("[mimo:agent] Initialized (max_turns=%d, max_history=%d)\n",
+         AGENT_MAX_TURNS, MIMO_MAX_MESSAGES);
+  return 0;
+}
+
+int mimo_agent_chat(const char *user_input, char **response)
+{
+  struct mimo_chat_req_s req;
+  struct mimo_chat_resp_s resp;
+  int turn;
+  int ret;
+
+  *response = NULL;
+
+  /* Add user message to history */
+
+  history_add(MIMO_ROLE_USER, user_input, NULL, NULL);
+
+  for (turn = 0; turn < AGENT_MAX_TURNS; turn++)
+    {
+      /* Build request */
+
+      memset(&req, 0, sizeof(req));
+      req.model         = MIMO_MODEL;
+      req.system_prompt  = MIMO_SYSTEM_PROMPT_EN;
+      req.messages       = g_history;
+      req.message_count  = g_history_count;
+      req.tools_json     = NULL;  /* TODO: wire tool schemas */
+      req.temperature    = MIMO_TEMPERATURE;
+
+      /* Call provider */
+
+      memset(&resp, 0, sizeof(resp));
+      ret = mimo_provider_chat(&req, &resp);
+      if (ret < 0)
+        {
+          fprintf(stderr, "[mimo:agent] Provider call failed\n");
+          history_add(MIMO_ROLE_ASSISTANT,
+                      "Sorry, I encountered an error.", NULL, NULL);
+          break;
+        }
+
+      if (resp.is_tool_use && resp.tool_name)
+        {
+          /* Tool use: add assistant message with reasoning_content,
+           * execute tool, add result, and continue loop.
+           */
+
+          printf("[mimo:agent] Tool call: %s\n", resp.tool_name);
+
+          history_add(MIMO_ROLE_ASSISTANT, resp.content,
+                      resp.tool_call_id, resp.reasoning_content);
+
+          /* TODO: Execute tool and get result.
+           * For now, return a placeholder error.
+           */
+
+          history_add(MIMO_ROLE_TOOL,
+                      "{\"error\":\"tool execution not implemented\"}",
+                      resp.tool_call_id, NULL);
+
+          mimo_chat_resp_free(&resp);
+          continue;
+        }
+
+      /* Final response */
+
+      if (resp.content)
+        {
+          history_add(MIMO_ROLE_ASSISTANT, resp.content, NULL,
+                      resp.reasoning_content);
+          *response = strdup(resp.content);
+        }
+
+      mimo_chat_resp_free(&resp);
+      break;
+    }
+
+  if (!*response)
+    {
+      *response = strdup("[MiMo] No response generated.");
+    }
+
+  return 0;
+}

--- a/mimo/mimo_main.c
+++ b/mimo/mimo_main.c
@@ -1,0 +1,175 @@
+/****************************************************************************
+ * packages/demos/mimo/mimo_main.c
+ *
+ * Copyright (C) 2024 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "mimo.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define INPUT_BUF_SIZE  1024
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static void print_banner(void)
+{
+  printf("\n");
+  printf("  MiMo - Xiaomi AI Assistant\n");
+  printf("  Model: %s\n", MIMO_MODEL);
+  printf("  Thinking: %s\n",
+#ifdef CONFIG_MIMO_ENABLE_THINKING
+         "on"
+#else
+         "off"
+#endif
+         );
+  printf("  Type 'quit' to exit.\n");
+  printf("\n");
+}
+
+static int run_interactive(void)
+{
+  char input[INPUT_BUF_SIZE];
+  char *response;
+  int ret;
+
+  print_banner();
+
+  while (1)
+    {
+      printf("You> ");
+      fflush(stdout);
+
+      if (!fgets(input, sizeof(input), stdin))
+        {
+          break;
+        }
+
+      /* Strip newline */
+
+      size_t len = strlen(input);
+      if (len > 0 && input[len - 1] == '\n')
+        {
+          input[len - 1] = '\0';
+        }
+
+      if (strlen(input) == 0)
+        {
+          continue;
+        }
+
+      if (strcmp(input, "quit") == 0 || strcmp(input, "exit") == 0)
+        {
+          break;
+        }
+
+      ret = mimo_agent_chat(input, &response);
+      if (ret == 0 && response)
+        {
+          printf("MiMo> %s\n\n", response);
+          free(response);
+        }
+      else
+        {
+          printf("MiMo> [error]\n\n");
+        }
+    }
+
+  return 0;
+}
+
+static int run_oneshot(const char *message)
+{
+  char *response;
+  int ret;
+
+  ret = mimo_agent_chat(message, &response);
+  if (ret == 0 && response)
+    {
+      printf("%s\n", response);
+      free(response);
+    }
+
+  return ret;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int main(int argc, char *argv[])
+{
+  int ret;
+
+  /* Initialize provider */
+
+  ret = mimo_provider_init(MIMO_API_KEY, MIMO_API_BASE_URL);
+  if (ret < 0)
+    {
+      fprintf(stderr, "[mimo] Provider init failed. "
+              "Check API key configuration.\n");
+      return ret;
+    }
+
+  /* Initialize agent */
+
+  ret = mimo_agent_init();
+  if (ret < 0)
+    {
+      fprintf(stderr, "[mimo] Agent init failed\n");
+      return ret;
+    }
+
+  /* Run mode: oneshot or interactive */
+
+  if (argc > 1)
+    {
+      /* Concatenate all args as the message */
+
+      char message[INPUT_BUF_SIZE];
+      message[0] = '\0';
+
+      int i;
+      for (i = 1; i < argc; i++)
+        {
+          if (i > 1)
+            {
+              strlcat(message, " ", sizeof(message));
+            }
+
+          strlcat(message, argv[i], sizeof(message));
+        }
+
+      ret = run_oneshot(message);
+    }
+  else
+    {
+      ret = run_interactive();
+    }
+
+  mimo_provider_destroy();
+  return ret;
+}

--- a/mimo/mimo_provider.c
+++ b/mimo/mimo_provider.c
@@ -1,0 +1,832 @@
+/****************************************************************************
+ * packages/demos/mimo/mimo_provider.c
+ *
+ * Copyright (C) 2024 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <netutils/cJSON.h>
+#include <netutils/webclient.h>
+
+#ifdef CONFIG_CRYPTO_MBEDTLS
+#  include <sys/socket.h>
+#  include <netinet/in.h>
+#  include <arpa/inet.h>
+#  include <netdb.h>
+#  include <unistd.h>
+#  include <mbedtls/ssl.h>
+#  include <mbedtls/entropy.h>
+#  include <mbedtls/ctr_drbg.h>
+#endif
+
+#include "mimo.h"
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static char g_api_key[256];
+static char g_base_url[MIMO_MAX_URL_LEN];
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/* Accumulator for HTTP response body received in chunks */
+
+struct http_resp_buf_s
+{
+  char  *data;
+  size_t len;
+  size_t cap;
+};
+
+#ifdef CONFIG_CRYPTO_MBEDTLS
+
+/* TLS context wrapping mbedtls state */
+
+struct mimo_tls_ctx_s
+{
+  mbedtls_entropy_context  entropy;
+  mbedtls_ctr_drbg_context ctr_drbg;
+  mbedtls_ssl_config       conf;
+};
+
+/* TLS connection wrapping a single mbedtls session.
+ * webclient_tls_connection is opaque (forward-declared only),
+ * so we cast our struct pointer to/from it as an opaque handle.
+ * We use a plain POSIX fd instead of mbedtls_net_context to
+ * avoid mbedtls_net_connect's getaddrinfo issues on NuttX.
+ */
+
+struct mimo_tls_conn_s
+{
+  mbedtls_ssl_context  ssl;
+  int                  fd;
+};
+#endif
+
+/****************************************************************************
+ * Private Functions - TLS
+ ****************************************************************************/
+
+#ifdef CONFIG_CRYPTO_MBEDTLS
+
+/* BIO callbacks for mbedtls using a plain fd */
+
+static int mimo_bio_send(void *ctx, const unsigned char *buf, size_t len)
+{
+  int fd = *(int *)ctx;
+  ssize_t ret = send(fd, buf, len, 0);
+  if (ret < 0)
+    {
+      return -EIO;
+    }
+
+  return (int)ret;
+}
+
+static int mimo_bio_recv(void *ctx, unsigned char *buf, size_t len)
+{
+  int fd = *(int *)ctx;
+  ssize_t ret = recv(fd, buf, len, 0);
+  if (ret < 0)
+    {
+      return -EIO;
+    }
+
+  if (ret == 0)
+    {
+      return MBEDTLS_ERR_SSL_WANT_READ;
+    }
+
+  return (int)ret;
+}
+
+static int mimo_tls_connect(FAR void *ctx,
+                            FAR const char *hostname,
+                            FAR const char *port,
+                            unsigned int timeout_sec,
+                            FAR struct webclient_tls_connection **connp)
+{
+  FAR struct mimo_tls_ctx_s *tctx = ctx;
+  FAR struct mimo_tls_conn_s *conn;
+  struct hostent *he;
+  struct sockaddr_in server;
+  int portnum;
+  int ret;
+  int fd;
+
+  printf("[mimo] TLS connecting to %s:%s\n", hostname, port);
+
+  /* Resolve hostname using gethostbyname (more reliable on NuttX) */
+
+  he = gethostbyname(hostname);
+  if (!he)
+    {
+      fprintf(stderr, "[mimo] DNS resolve failed for %s\n", hostname);
+      return -EIO;
+    }
+
+  /* Create TCP socket and connect */
+
+  fd = socket(AF_INET, SOCK_STREAM, 0);
+  if (fd < 0)
+    {
+      fprintf(stderr, "[mimo] socket() failed: %d\n", errno);
+      return -EIO;
+    }
+
+  portnum = atoi(port);
+  memset(&server, 0, sizeof(server));
+  server.sin_family = AF_INET;
+  server.sin_port = htons(portnum);
+  memcpy(&server.sin_addr, he->h_addr_list[0], he->h_length);
+
+  printf("[mimo] Connecting to %s (%s:%d)\n",
+         hostname, inet_ntoa(server.sin_addr), portnum);
+
+  if (connect(fd, (struct sockaddr *)&server, sizeof(server)) < 0)
+    {
+      fprintf(stderr, "[mimo] TCP connect failed: %d\n", errno);
+      close(fd);
+      return -EIO;
+    }
+
+  printf("[mimo] TCP connected, starting TLS handshake\n");
+
+  /* Allocate TLS connection wrapper */
+
+  conn = calloc(1, sizeof(*conn));
+  if (!conn)
+    {
+      close(fd);
+      return -ENOMEM;
+    }
+
+  conn->fd = fd;
+  mbedtls_ssl_init(&conn->ssl);
+
+  ret = mbedtls_ssl_setup(&conn->ssl, &tctx->conf);
+  if (ret != 0)
+    {
+      fprintf(stderr, "[mimo] TLS ssl setup failed: -0x%x\n", -ret);
+      goto err;
+    }
+
+  ret = mbedtls_ssl_set_hostname(&conn->ssl, hostname);
+  if (ret != 0)
+    {
+      fprintf(stderr, "[mimo] TLS set hostname failed: -0x%x\n", -ret);
+      goto err;
+    }
+
+  mbedtls_ssl_set_bio(&conn->ssl, &conn->fd,
+                       mimo_bio_send, mimo_bio_recv, NULL);
+
+  while ((ret = mbedtls_ssl_handshake(&conn->ssl)) != 0)
+    {
+      if (ret != MBEDTLS_ERR_SSL_WANT_READ &&
+          ret != MBEDTLS_ERR_SSL_WANT_WRITE)
+        {
+          fprintf(stderr, "[mimo] TLS handshake failed: -0x%x\n", -ret);
+          goto err;
+        }
+    }
+
+  printf("[mimo] TLS handshake complete\n");
+
+  *connp = (FAR struct webclient_tls_connection *)conn;
+  return 0;
+
+err:
+  mbedtls_ssl_free(&conn->ssl);
+  close(conn->fd);
+  free(conn);
+  return -EIO;
+}
+
+static ssize_t mimo_tls_send(FAR void *ctx,
+                             FAR struct webclient_tls_connection *base,
+                             FAR const void *buf, size_t len)
+{
+  FAR struct mimo_tls_conn_s *conn = (FAR struct mimo_tls_conn_s *)base;
+  int ret;
+
+  (void)ctx;
+  ret = mbedtls_ssl_write(&conn->ssl, buf, len);
+  if (ret < 0)
+    {
+      if (ret == MBEDTLS_ERR_SSL_WANT_WRITE)
+        {
+          return 0;
+        }
+
+      return -EIO;
+    }
+
+  return ret;
+}
+
+static ssize_t mimo_tls_recv(FAR void *ctx,
+                             FAR struct webclient_tls_connection *base,
+                             FAR void *buf, size_t len)
+{
+  FAR struct mimo_tls_conn_s *conn = (FAR struct mimo_tls_conn_s *)base;
+  int ret;
+
+  (void)ctx;
+  ret = mbedtls_ssl_read(&conn->ssl, buf, len);
+  if (ret < 0)
+    {
+      if (ret == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY)
+        {
+          return 0;
+        }
+
+      if (ret == MBEDTLS_ERR_SSL_WANT_READ)
+        {
+          return 0;
+        }
+
+      return -EIO;
+    }
+
+  return ret;
+}
+
+static int mimo_tls_close(FAR void *ctx,
+                          FAR struct webclient_tls_connection *base)
+{
+  FAR struct mimo_tls_conn_s *conn = (FAR struct mimo_tls_conn_s *)base;
+
+  (void)ctx;
+  mbedtls_ssl_close_notify(&conn->ssl);
+  mbedtls_ssl_free(&conn->ssl);
+  close(conn->fd);
+  free(conn);
+  return 0;
+}
+
+static int mimo_tls_get_poll_info(
+    FAR void *ctx,
+    FAR struct webclient_tls_connection *base,
+    FAR struct webclient_poll_info *info)
+{
+  FAR struct mimo_tls_conn_s *conn = (FAR struct mimo_tls_conn_s *)base;
+
+  (void)ctx;
+  info->fd = conn->fd;
+  info->flags = WEBCLIENT_POLL_INFO_WANT_READ;
+  return 0;
+}
+
+static const struct webclient_tls_ops g_mimo_tls_ops =
+{
+  .connect        = mimo_tls_connect,
+  .send           = mimo_tls_send,
+  .recv           = mimo_tls_recv,
+  .close          = mimo_tls_close,
+  .get_poll_info  = mimo_tls_get_poll_info,
+  .init_connection = NULL,
+};
+
+static struct mimo_tls_ctx_s g_tls_ctx;
+static bool g_tls_initialized = false;
+
+static int mimo_tls_init(void)
+{
+  int ret;
+
+  if (g_tls_initialized)
+    {
+      return 0;
+    }
+
+  mbedtls_entropy_init(&g_tls_ctx.entropy);
+  mbedtls_ctr_drbg_init(&g_tls_ctx.ctr_drbg);
+  mbedtls_ssl_config_init(&g_tls_ctx.conf);
+
+  ret = mbedtls_ctr_drbg_seed(&g_tls_ctx.ctr_drbg,
+                               mbedtls_entropy_func,
+                               &g_tls_ctx.entropy,
+                               (const unsigned char *)"mimo", 4);
+  if (ret != 0)
+    {
+      fprintf(stderr, "[mimo] TLS drbg seed failed: -0x%x\n", -ret);
+      return -1;
+    }
+
+  ret = mbedtls_ssl_config_defaults(&g_tls_ctx.conf,
+                                     MBEDTLS_SSL_IS_CLIENT,
+                                     MBEDTLS_SSL_TRANSPORT_STREAM,
+                                     MBEDTLS_SSL_PRESET_DEFAULT);
+  if (ret != 0)
+    {
+      fprintf(stderr, "[mimo] TLS config defaults failed: -0x%x\n", -ret);
+      return -1;
+    }
+
+  /* Skip server certificate verification for embedded use.
+   * For production, configure CA certificates here.
+   */
+
+  mbedtls_ssl_conf_authmode(&g_tls_ctx.conf, MBEDTLS_SSL_VERIFY_NONE);
+  mbedtls_ssl_conf_rng(&g_tls_ctx.conf, mbedtls_ctr_drbg_random,
+                        &g_tls_ctx.ctr_drbg);
+
+  g_tls_initialized = true;
+  return 0;
+}
+
+static void mimo_tls_deinit(void)
+{
+  if (!g_tls_initialized)
+    {
+      return;
+    }
+
+  mbedtls_ssl_config_free(&g_tls_ctx.conf);
+  mbedtls_ctr_drbg_free(&g_tls_ctx.ctr_drbg);
+  mbedtls_entropy_free(&g_tls_ctx.entropy);
+  g_tls_initialized = false;
+}
+#endif /* CONFIG_CRYPTO_MBEDTLS */
+
+/****************************************************************************
+ * Private Functions - HTTP
+ ****************************************************************************/
+
+/**
+ * Sink callback for webclient: accumulates response body chunks.
+ */
+
+static int http_sink_callback(FAR char **buffer, int offset,
+                              int datend, FAR int *buflen,
+                              FAR void *arg)
+{
+  FAR struct http_resp_buf_s *resp = arg;
+  int len = datend - offset;
+
+  if (len <= 0)
+    {
+      return 0;
+    }
+
+  /* Grow buffer if needed */
+
+  while (resp->len + len + 1 > resp->cap)
+    {
+      size_t newcap = resp->cap ? resp->cap * 2 : 4096;
+      char *newdata = realloc(resp->data, newcap);
+      if (!newdata)
+        {
+          fprintf(stderr, "[mimo] OOM in sink callback\n");
+          return -ENOMEM;
+        }
+
+      resp->data = newdata;
+      resp->cap = newcap;
+    }
+
+  memcpy(resp->data + resp->len, &((*buffer)[offset]), len);
+  resp->len += len;
+  resp->data[resp->len] = '\0';
+  return 0;
+}
+
+/****************************************************************************
+ * Private Functions - Request Builder
+ ****************************************************************************/
+
+/**
+ * Build MiMo request body (OpenAI chat completions + MiMo extensions).
+ */
+
+static cJSON *build_request_body(const struct mimo_chat_req_s *req)
+{
+  cJSON *root = cJSON_CreateObject();
+  cJSON *messages;
+  int i;
+
+  cJSON_AddStringToObject(root, "model", req->model);
+
+  /* MiMo recommended: top_p=0.95 */
+
+  cJSON_AddNumberToObject(root, "top_p", 0.95);
+
+  if (req->temperature > 0)
+    {
+      cJSON_AddNumberToObject(root, "temperature",
+                              (double)req->temperature / 100.0);
+    }
+
+  cJSON_AddNumberToObject(root, "max_tokens", 8192);
+
+  /* Enable thinking mode if configured */
+
+#ifdef CONFIG_MIMO_ENABLE_THINKING
+  {
+    cJSON *kwargs = cJSON_CreateObject();
+    cJSON_AddTrueToObject(kwargs, "enable_thinking");
+    cJSON_AddItemToObject(root, "chat_template_kwargs", kwargs);
+  }
+#endif
+
+  /* Build messages array */
+
+  messages = cJSON_AddArrayToObject(root, "messages");
+
+  /* System prompt */
+
+  if (req->system_prompt && strlen(req->system_prompt) > 0)
+    {
+      cJSON *sys = cJSON_CreateObject();
+      cJSON_AddStringToObject(sys, "role", "system");
+      cJSON_AddStringToObject(sys, "content", req->system_prompt);
+      cJSON_AddItemToArray(messages, sys);
+    }
+
+  /* Conversation messages */
+
+  for (i = 0; i < req->message_count; i++)
+    {
+      cJSON *msg = cJSON_CreateObject();
+      const char *role_str;
+
+      switch (req->messages[i].role)
+        {
+          case MIMO_ROLE_USER:
+            role_str = "user";
+            break;
+          case MIMO_ROLE_ASSISTANT:
+            role_str = "assistant";
+            break;
+          case MIMO_ROLE_TOOL:
+            role_str = "tool";
+            break;
+          default:
+            role_str = "user";
+            break;
+        }
+
+      cJSON_AddStringToObject(msg, "role", role_str);
+
+      if (req->messages[i].content)
+        {
+          cJSON_AddStringToObject(msg, "content",
+                                  req->messages[i].content);
+        }
+
+      if (req->messages[i].tool_call_id)
+        {
+          cJSON_AddStringToObject(msg, "tool_call_id",
+                                  req->messages[i].tool_call_id);
+        }
+
+      /* Preserve reasoning_content for multi-turn tool calls
+       * in thinking mode (MiMo requirement: all history
+       * reasoning_content must be sent back).
+       */
+
+      if (req->messages[i].role == MIMO_ROLE_ASSISTANT &&
+          req->messages[i].reasoning_content)
+        {
+          cJSON_AddStringToObject(msg, "reasoning_content",
+                                  req->messages[i].reasoning_content);
+        }
+
+      cJSON_AddItemToArray(messages, msg);
+    }
+
+  /* Tools (OpenAI function calling format) */
+
+#ifdef CONFIG_MIMO_ENABLE_TOOLS
+  if (req->tools_json && strlen(req->tools_json) > 0)
+    {
+      cJSON *tools = cJSON_Parse(req->tools_json);
+      if (tools)
+        {
+          cJSON_AddItemToObject(root, "tools", tools);
+        }
+    }
+#endif
+
+  return root;
+}
+
+/**
+ * Parse MiMo response.
+ *
+ * Handles standard OpenAI fields plus MiMo's reasoning_content
+ * extension returned alongside tool_calls in thinking mode.
+ */
+
+static int parse_response(const char *json_str,
+                          struct mimo_chat_resp_s *resp)
+{
+  cJSON *root;
+  cJSON *choices;
+  cJSON *choice;
+  cJSON *message;
+  cJSON *content;
+  cJSON *tool_calls;
+
+  memset(resp, 0, sizeof(*resp));
+
+  root = cJSON_Parse(json_str);
+  if (!root)
+    {
+      fprintf(stderr, "[mimo] JSON parse error\n");
+      return -1;
+    }
+
+  /* Check for API error */
+
+  cJSON *error = cJSON_GetObjectItem(root, "error");
+  if (error)
+    {
+      cJSON *errmsg = cJSON_GetObjectItem(error, "message");
+      fprintf(stderr, "[mimo] API error: %s\n",
+              errmsg ? errmsg->valuestring : "unknown");
+      cJSON_Delete(root);
+      return -1;
+    }
+
+  choices = cJSON_GetObjectItem(root, "choices");
+  if (!choices || cJSON_GetArraySize(choices) == 0)
+    {
+      fprintf(stderr, "[mimo] No choices in response\n");
+      cJSON_Delete(root);
+      return -1;
+    }
+
+  choice = cJSON_GetArrayItem(choices, 0);
+  message = cJSON_GetObjectItem(choice, "message");
+  if (!message)
+    {
+      cJSON_Delete(root);
+      return -1;
+    }
+
+  /* Extract reasoning_content (MiMo thinking mode) */
+
+  cJSON *reasoning = cJSON_GetObjectItem(message, "reasoning_content");
+  if (reasoning && reasoning->valuestring)
+    {
+      resp->reasoning_content = strdup(reasoning->valuestring);
+      printf("[mimo] Thinking: %.80s%s\n",
+             reasoning->valuestring,
+             strlen(reasoning->valuestring) > 80 ? "..." : "");
+    }
+
+  /* Extract content */
+
+  content = cJSON_GetObjectItem(message, "content");
+  if (content && content->valuestring)
+    {
+      resp->content = strdup(content->valuestring);
+    }
+
+  /* Check for tool calls (OpenAI format) */
+
+  tool_calls = cJSON_GetObjectItem(message, "tool_calls");
+  if (tool_calls && cJSON_GetArraySize(tool_calls) > 0)
+    {
+      cJSON *tc = cJSON_GetArrayItem(tool_calls, 0);
+      cJSON *tc_id = cJSON_GetObjectItem(tc, "id");
+      cJSON *func = cJSON_GetObjectItem(tc, "function");
+
+      if (func)
+        {
+          cJSON *fname = cJSON_GetObjectItem(func, "name");
+          cJSON *fargs = cJSON_GetObjectItem(func, "arguments");
+
+          resp->is_tool_use = true;
+
+          if (tc_id && tc_id->valuestring)
+            {
+              resp->tool_call_id = strdup(tc_id->valuestring);
+            }
+
+          if (fname && fname->valuestring)
+            {
+              resp->tool_name = strdup(fname->valuestring);
+            }
+
+          if (fargs && fargs->valuestring)
+            {
+              resp->tool_input = strdup(fargs->valuestring);
+            }
+        }
+    }
+
+  cJSON_Delete(root);
+  return 0;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int mimo_provider_init(const char *api_key, const char *base_url)
+{
+  if (!api_key || strlen(api_key) == 0)
+    {
+      fprintf(stderr, "[mimo] API key not configured\n");
+      return -1;
+    }
+
+  strncpy(g_api_key, api_key, sizeof(g_api_key) - 1);
+  strncpy(g_base_url, base_url, sizeof(g_base_url) - 1);
+
+  printf("[mimo] Provider initialized\n");
+  printf("[mimo] Endpoint: %s\n", g_base_url);
+  printf("[mimo] Thinking mode: %s\n",
+#ifdef CONFIG_MIMO_ENABLE_THINKING
+         "enabled"
+#else
+         "disabled"
+#endif
+         );
+  return 0;
+}
+
+int mimo_provider_chat(const struct mimo_chat_req_s *req,
+                       struct mimo_chat_resp_s *resp)
+{
+  cJSON *body;
+  char *body_str;
+  char auth_header[300];
+  const char *headers[2];
+  struct webclient_context ctx;
+  struct http_resp_buf_s resp_buf;
+  char *work_buf;
+  int ret;
+
+  body = build_request_body(req);
+  if (!body)
+    {
+      return -1;
+    }
+
+  body_str = cJSON_PrintUnformatted(body);
+  cJSON_Delete(body);
+
+  if (!body_str)
+    {
+      return -1;
+    }
+
+  printf("[mimo] POST %s (%d bytes)\n",
+         g_base_url, (int)strlen(body_str));
+
+  /* Prepare HTTP headers */
+
+  snprintf(auth_header, sizeof(auth_header),
+           "Authorization: Bearer %s", g_api_key);
+  headers[0] = "Content-Type: application/json";
+  headers[1] = auth_header;
+
+  /* Allocate work buffer for webclient (used for HTTP header I/O) */
+
+  work_buf = malloc(2048);
+  if (!work_buf)
+    {
+      free(body_str);
+      return -1;
+    }
+
+  /* Initialize response accumulator */
+
+  memset(&resp_buf, 0, sizeof(resp_buf));
+
+  /* Set up webclient context */
+
+  webclient_set_defaults(&ctx);
+  ctx.protocol_version = WEBCLIENT_PROTOCOL_VERSION_HTTP_1_1;
+  ctx.method   = "POST";
+  ctx.url      = g_base_url;
+  ctx.buffer   = work_buf;
+  ctx.buflen   = 2048;
+  ctx.headers  = headers;
+  ctx.nheaders = 2;
+  ctx.sink_callback     = http_sink_callback;
+  ctx.sink_callback_arg = &resp_buf;
+  ctx.timeout_sec       = 60;
+
+#ifdef CONFIG_CRYPTO_MBEDTLS
+  /* Enable TLS for HTTPS */
+
+  ret = mimo_tls_init();
+  if (ret < 0)
+    {
+      fprintf(stderr, "[mimo] TLS init failed\n");
+      free(work_buf);
+      free(body_str);
+      return -1;
+    }
+
+  ctx.tls_ops = &g_mimo_tls_ops;
+  ctx.tls_ctx = &g_tls_ctx;
+#endif
+
+  webclient_set_static_body(&ctx, body_str, strlen(body_str));
+
+  ret = webclient_perform(&ctx);
+
+  free(work_buf);
+  free(body_str);
+
+  if (ret < 0)
+    {
+      fprintf(stderr, "[mimo] HTTP request failed: %d\n", ret);
+      if (resp_buf.data)
+        {
+          free(resp_buf.data);
+        }
+
+      return -1;
+    }
+
+  printf("[mimo] HTTP %d, response %zu bytes\n",
+         ctx.http_status, resp_buf.len);
+
+  if (ctx.http_status != 200 || !resp_buf.data)
+    {
+      fprintf(stderr, "[mimo] HTTP error %d: %s\n",
+              ctx.http_status,
+              resp_buf.data ? resp_buf.data : "(empty)");
+      if (resp_buf.data)
+        {
+          free(resp_buf.data);
+        }
+
+      return -1;
+    }
+
+  /* Parse the JSON response */
+
+  ret = parse_response(resp_buf.data, resp);
+  free(resp_buf.data);
+
+  return ret;
+}
+
+void mimo_chat_resp_free(struct mimo_chat_resp_s *resp)
+{
+  if (resp->content)
+    {
+      free(resp->content);
+      resp->content = NULL;
+    }
+
+  if (resp->tool_call_id)
+    {
+      free(resp->tool_call_id);
+      resp->tool_call_id = NULL;
+    }
+
+  if (resp->tool_name)
+    {
+      free(resp->tool_name);
+      resp->tool_name = NULL;
+    }
+
+  if (resp->tool_input)
+    {
+      free(resp->tool_input);
+      resp->tool_input = NULL;
+    }
+
+  if (resp->reasoning_content)
+    {
+      free(resp->reasoning_content);
+      resp->reasoning_content = NULL;
+    }
+}
+
+void mimo_provider_destroy(void)
+{
+  memset(g_api_key, 0, sizeof(g_api_key));
+#ifdef CONFIG_CRYPTO_MBEDTLS
+  mimo_tls_deinit();
+#endif
+}


### PR DESCRIPTION
Add a standalone Xiaomi MiMo large language model provider demo for OpenVela/NuttX with the following features:

- OpenAI-compatible Chat Completions API
- MiMo thinking mode (reasoning_content) for chain-of-thought
- Function calling / tool use support
- Interactive REPL and single-shot CLI modes
- Secure HTTPS communication via mbedTLS
- Automatic conversation history management (multi-turn)

Architecture:
- Provider layer: HTTP/TLS communication, JSON request/response
- Agent layer: conversation history, ReAct tool-calling loop
- Main layer: CLI entry point (interactive + single-shot)

Model: mimo-v2-flash (309B/15B MoE, 262K context window)

*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*

