### PR TITLE
bailian: add Alibaba Bailian voice SDK adaptation for goldfish

### DIFF
--- a/bailian/CMakeLists.txt
+++ b/bailian/CMakeLists.txt
@@ -1,0 +1,81 @@
+# ##############################################################################
+# packages/demos/bailian/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_AI_BAILIAN)
+
+  set(BAILIAN_SDK_DIR ${NUTTX_DIR}/../external/bailian_sdk)
+
+  # HAL layer sources - these implement the SDK's required interfaces
+  set(HAL_SRCS
+      hal/hal_mem.c
+      hal/hal_time.c
+      hal/hal_random.c
+      hal/hal_storage.c
+      hal/hal_mutex.c)
+
+  # Application sources
+  set(APP_SRCS
+      bailian_main.c
+      net/http_client.c
+      net/websocket.c
+      audio/recorder.c
+      audio/player.c)
+
+  # Create HAL library first - this provides symbols needed by SDK
+  nuttx_add_library(bailian_hal STATIC)
+  target_sources(bailian_hal PRIVATE ${HAL_SRCS})
+  target_include_directories(bailian_hal PRIVATE
+    ${BAILIAN_SDK_DIR}/include
+    ${BAILIAN_SDK_DIR}/include/c_utils)
+
+  # Create the main application
+  nuttx_add_application(
+    MODULE
+    ${CONFIG_AI_BAILIAN}
+    NAME
+    ${CONFIG_AI_BAILIAN_PROGNAME}
+    SRCS
+    ${APP_SRCS}
+    STACKSIZE
+    ${CONFIG_AI_BAILIAN_STACKSIZE}
+    PRIORITY
+    ${CONFIG_AI_BAILIAN_PRIORITY}
+    INCLUDE_DIRECTORIES
+    ${BAILIAN_SDK_DIR}/include
+    ${BAILIAN_SDK_DIR}/include/c_utils
+    ${BAILIAN_SDK_DIR}/third_party/cJSON
+    ${BAILIAN_SDK_DIR}/third_party/tinycrypt/include)
+
+  # Link SDK libraries with HAL library using whole-archive to ensure all HAL symbols are included
+  target_link_libraries(apps_${CONFIG_AI_BAILIAN_PROGNAME}
+    PRIVATE
+    -Wl,--whole-archive
+    bailian_hal
+    -Wl,--no-whole-archive
+    -Wl,--start-group
+    ${BAILIAN_SDK_DIR}/libs/libqwen_sdk.a
+    # libc_license.a removed - using pay-as-you-go mode
+    ${BAILIAN_SDK_DIR}/libs/libc_mmi_cmd.a
+    ${BAILIAN_SDK_DIR}/libs/libqwen_test.a
+    ${BAILIAN_SDK_DIR}/third_party/cJSON/libcjson.a
+    ${BAILIAN_SDK_DIR}/third_party/tinycrypt/libtinycrypt.a
+    -Wl,--end-group)
+
+endif()

--- a/bailian/Kconfig
+++ b/bailian/Kconfig
@@ -1,0 +1,52 @@
+config AI_BAILIAN
+	tristate "Bailian SDK adaptation"
+	default n
+	select AUDIOUTILS_NXAUDIO
+	select SYSTEM_NXRECORDER
+	---help---
+		Enable the openvela Bailian SDK adaptation example.
+
+if AI_BAILIAN
+
+config AI_BAILIAN_PROGNAME
+	string "Program name"
+	default "bailian"
+	---help---
+		This is the name of the program that will be used when the NSH ELF
+		program is installed.
+
+config AI_BAILIAN_PRIORITY
+	int "Bailian task priority"
+	default 100
+
+config AI_BAILIAN_STACKSIZE
+	int "Bailian stack size"
+	default 8192
+
+config AI_BAILIAN_HEAPSIZE
+	int "Bailian heap size"
+	depends on MM_TASK_HEAP
+	default MM_TASK_HEAP_DEFAULT_SIZE
+
+config AI_BAILIAN_WORKSPACE_ID
+	string "Workspace ID"
+	default ""
+
+config AI_BAILIAN_APP_ID
+	string "App ID"
+	default ""
+
+config AI_BAILIAN_API_KEY
+	string "API Key"
+	default ""
+
+# License mode configs removed - using pay-as-you-go mode
+config AI_BAILIAN_RECORDER_DEV
+	string "Recorder device path"
+	default "/dev/audio/pcm0c"
+
+config AI_BAILIAN_PLAYER_DEV
+	string "Player device path"
+	default "/dev/audio/pcm0p"
+
+endif

--- a/bailian/Make.defs
+++ b/bailian/Make.defs
@@ -1,0 +1,23 @@
+############################################################################
+# packages/demos/bailian/Make.defs
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifneq ($(CONFIG_AI_BAILIAN),)
+CONFIGURED_APPS += $(APPDIR)/packages/demos/bailian
+endif

--- a/bailian/Makefile
+++ b/bailian/Makefile
@@ -1,0 +1,65 @@
+############################################################################
+# packages/demos/bailian/Makefile
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+include $(APPDIR)/Make.defs
+
+PROGNAME  = $(CONFIG_AI_BAILIAN_PROGNAME)
+PRIORITY  = $(CONFIG_AI_BAILIAN_PRIORITY)
+STACKSIZE = $(CONFIG_AI_BAILIAN_STACKSIZE)
+HEAPSIZE  = $(CONFIG_AI_BAILIAN_HEAPSIZE)
+MODULE    = $(CONFIG_AI_BAILIAN)
+
+MAINSRC = bailian_main.c
+
+CSRCS = \
+	hal/hal_mem.c \
+	hal/hal_time.c \
+	hal/hal_random.c \
+	hal/hal_storage.c \
+	hal/hal_mutex.c \
+	net/http_client.c \
+	net/websocket.c \
+	audio/recorder.c \
+	audio/player.c
+
+BAILIAN_DIR = $(APPDIR)/../external/bailian_sdk
+SDK_INCDIR = $(BAILIAN_DIR)/include
+SDK_LIBDIR = $(BAILIAN_DIR)/libs
+
+CFLAGS += ${INCDIR_PREFIX}"$(SDK_INCDIR)"
+CFLAGS += ${INCDIR_PREFIX}"$(SDK_INCDIR)/c_utils"
+CFLAGS += ${INCDIR_PREFIX}"$(APPDIR)/include/netutils"
+
+# Copy SDK libraries to staging directory for linking
+context::
+	$(Q) cp -f $(SDK_LIBDIR)/libqwen_sdk.a $(APPDIR)/staging/
+	$(Q) # libc_license.a removed - using pay-as-you-go mode
+	$(Q) cp -f $(SDK_LIBDIR)/libc_mmi_cmd.a $(APPDIR)/staging/
+	$(Q) cp -f $(SDK_LIBDIR)/libc_mmi_cmd_application.a $(APPDIR)/staging/
+	$(Q) cp -f $(SDK_LIBDIR)/libc_mmi_cmd_voice_translate.a $(APPDIR)/staging/
+	$(Q) cp -f $(SDK_LIBDIR)/libc_mmi_cmd_volume.a $(APPDIR)/staging/
+	$(Q) cp -f $(SDK_LIBDIR)/libc_visual.a $(APPDIR)/staging/
+	$(Q) cp -f $(BAILIAN_DIR)/third_party/tinycrypt/libtinycrypt.a $(APPDIR)/staging/
+	$(Q) cp -f $(SDK_LIBDIR)/libqwen_test.a $(APPDIR)/staging/
+
+# Link SDK libraries
+LDLIBS += -lqwen_test
+
+include $(APPDIR)/Application.mk

--- a/bailian/README.md
+++ b/bailian/README.md
@@ -1,0 +1,117 @@
+# Bailian (百炼) SDK Adaptation for openvela
+
+本模块实现了阿里云百炼 (Model Studio) 语音交互 SDK 在 openvela goldfish 模拟器上的适配，支持通过 virtio-snd 音频设备完成实时语音对话（ASR → LLM → TTS）。
+
+## 前置条件
+
+1. 百炼 SDK 已放置在 `external/bailian_sdk/` 目录
+2. 已在[阿里云百炼控制台](https://bailian.console.aliyun.com/)创建应用，获取以下凭证：
+   - **Workspace ID**（工作空间 ID）
+   - **App ID**（应用 ID）
+   - **API Key**（后付费模式）
+
+## defconfig 配置
+
+在目标板的 defconfig 中添加以下配置项：
+
+### 必选配置
+
+```
+# 启用百炼适配模块
+CONFIG_AI_BAILIAN=y
+CONFIG_AI_BAILIAN_STACKSIZE=32768
+
+# 填入你自己的百炼凭证
+CONFIG_AI_BAILIAN_WORKSPACE_ID="your-workspace-id"
+CONFIG_AI_BAILIAN_APP_ID="your-app-id"
+CONFIG_AI_BAILIAN_API_KEY="your-api-key"
+
+# TLS 支持（WebSocket 连接百炼服务端需要）
+CONFIG_CRYPTO_MBEDTLS=y
+
+# 网络（需要 DNS 和路由）
+CONFIG_NETDB_DNSSERVER_IPv4=y
+CONFIG_NETDB_DNSSERVER_IPv4ADDR=0x08080808
+CONFIG_NET_ROUTE=y
+
+# 默认任务栈大小（SDK 内部线程需要较大栈空间）
+CONFIG_DEFAULT_TASK_STACKSIZE=16384
+```
+
+### 音频相关配置（goldfish 模拟器）
+
+```
+# virtio-snd 驱动
+CONFIG_DRIVERS_VIRTIO_SOUND=y
+
+# nxaudio 库（播放器依赖）
+CONFIG_AUDIOUTILS_NXAUDIO_LIB=y
+
+# ALSA 兼容库
+CONFIG_AUDIOUTILS_ALSA_LIB=y
+```
+
+### 可选配置
+
+```
+# 自定义录音/播放设备路径（默认值通常无需修改）
+CONFIG_AI_BAILIAN_RECORDER_DEV="/dev/audio/pcm0c"
+CONFIG_AI_BAILIAN_PLAYER_DEV="/dev/audio/pcm0p"
+```
+
+> **注意**：修改 defconfig 后需要删除 `cmake_out/` 目录重新编译。
+
+## 编译
+
+```bash
+./build.sh vendor/openvela/boards/vela/configs/goldfish-armeabi-v7a-ap --cmake
+```
+
+## 运行（goldfish 模拟器）
+
+### 基本启动
+
+```bash
+./emulator.sh cmake_out/vela_goldfish-armeabi-v7a-ap -gpu off
+```
+
+### 使用主机 USB 麦克风/耳机
+
+通过环境变量指定 PulseAudio 音频设备（不修改 emulator.sh）：
+
+```bash
+QEMU_AUDIO_DRV=pa \
+  PULSE_SERVER=unix:/run/user/1000/pulse/native \
+  QEMU_PA_SOURCE=<your-pa-source-name> \
+  QEMU_PA_SINK=<your-pa-sink-name> \
+  ./emulator.sh cmake_out/vela_goldfish-armeabi-v7a-ap -gpu off
+```
+
+查看可用的 PulseAudio 设备：
+
+```bash
+# 查看录音设备（source）
+pactl list sources short
+
+# 查看播放设备（sink）
+pactl list sinks short
+```
+
+### NSH 中操作
+
+```
+openvela-ap> ifup eth0        # 启用网络
+openvela-ap> renew eth0       # 获取 IP（DHCP）
+openvela-ap> bailian          # 启动百炼语音交互
+```
+
+启动后按键操作：
+- `t` — 开始录音（对着麦克风说话）
+- `s` — 停止录音（等待 ASR → LLM → TTS 回复）
+- `q` — 退出
+
+## 已知限制
+
+- virtio-snd 不支持 24kHz 采样率，播放端使用 48kHz 并对 TTS 24kHz 音频做 2x 上采样
+- 首次录音时 PulseAudio capture 源可能处于 IDLE 状态，代码中已实现 warmup 循环自动激活
+- 当前对话延迟约 45 秒，主要瓶颈在 SDK 内部状态机等待，后续版本将优化

--- a/bailian/audio/player.c
+++ b/bailian/audio/player.c
@@ -1,0 +1,545 @@
+/****************************************************************************
+ * apps/ai/bailian/audio/player.c
+ *
+ * Audio player using nxaudio library for openvela bailian SDK
+ ****************************************************************************/
+
+#include <errno.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <sched.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <nuttx/config.h>
+
+#ifdef CONFIG_AUDIOUTILS_NXAUDIO_LIB
+#include <nuttx/audio/audio.h>
+#include <audioutils/nxaudio.h>
+#endif
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define PLAYER_STATE_IDLE     0
+#define PLAYER_STATE_INIT     1
+#define PLAYER_STATE_PLAYING  2
+#define PLAYER_STATE_PAUSED   3
+#define PLAYER_STATE_STOPPED  4
+
+#define PLAYER_MODE_FILE      0
+#define PLAYER_MODE_STREAM    1
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/* WAV file header structures */
+
+struct wav_riff_s
+{
+  char     chunk_id[4];    /* "RIFF" */
+  uint32_t chunk_size;
+  char     format[4];      /* "WAVE" */
+};
+
+struct wav_fmt_s
+{
+  char     subchunk1_id[4];   /* "fmt " */
+  uint32_t subchunk1_size;
+  uint16_t audio_format;
+  uint16_t num_channels;
+  uint32_t sample_rate;
+  uint32_t byte_rate;
+  uint16_t block_align;
+  uint16_t bits_per_sample;
+};
+
+struct wav_data_s
+{
+  char     subchunk2_id[4];   /* "data" */
+  uint32_t subchunk2_size;
+};
+
+struct wav_header_s
+{
+  struct wav_riff_s riff;
+  struct wav_fmt_s  fmt;
+  struct wav_data_s data;
+};
+
+struct bailian_player
+{
+#ifdef CONFIG_AUDIOUTILS_NXAUDIO_LIB
+  struct nxaudio_s nxaudio;
+#endif
+  struct wav_header_s wav;
+  int fd;                    /* Read fd (file or pipe read end) */
+  int write_fd;              /* Pipe write end for streaming mode */
+  volatile int state;
+  pthread_t thread_id;
+  uint32_t file_position;
+  int mode;                  /* PLAYER_MODE_FILE or PLAYER_MODE_STREAM */
+};
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+#ifdef CONFIG_AUDIOUTILS_NXAUDIO_LIB
+static void player_dequeue_cb(unsigned long arg, FAR struct ap_buffer_s *apb);
+static void player_complete_cb(unsigned long arg);
+static void player_user_cb(unsigned long arg, FAR struct audio_msg_s *msg,
+                           FAR bool *running);
+#endif
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#ifdef CONFIG_AUDIOUTILS_NXAUDIO_LIB
+static struct nxaudio_callbacks_s g_player_cbs =
+{
+  player_dequeue_cb,
+  player_complete_cb,
+  player_user_cb
+};
+#endif
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_AUDIOUTILS_NXAUDIO_LIB
+static void player_dequeue_cb(unsigned long arg, FAR struct ap_buffer_s *apb)
+{
+  FAR struct bailian_player *player = (FAR struct bailian_player *)(uintptr_t)arg;
+  ssize_t bytes_read;
+
+  if (!apb || !player)
+    {
+      return;
+    }
+
+  if (player->fd < 0)
+    {
+      apb->nbytes = 0;
+      return;
+    }
+
+  bytes_read = read(player->fd, apb->samp, apb->nmaxbytes);
+  if (bytes_read < 0)
+    {
+      apb->nbytes = 0;
+      return;
+    }
+
+  apb->nbytes = (size_t)bytes_read;
+  apb->curbyte = 0;
+  apb->flags = 0;
+
+  while (apb->nbytes < apb->nmaxbytes)
+    {
+      int n = apb->nmaxbytes - apb->nbytes;
+      int ret = read(player->fd, &apb->samp[apb->nbytes], n);
+      if (ret <= 0)
+        {
+          break;
+        }
+
+      apb->nbytes += ret;
+    }
+
+  player->file_position += apb->nbytes;
+
+  if (apb->nbytes < apb->nmaxbytes)
+    {
+      if (player->mode == PLAYER_MODE_FILE)
+        {
+          close(player->fd);
+          player->fd = -1;
+        }
+
+      if (apb->nbytes > 0)
+        {
+          apb->flags = AUDIO_APB_FINAL;
+          nxaudio_enqbuffer(&player->nxaudio, apb);
+        }
+
+      return;
+    }
+
+  nxaudio_enqbuffer(&player->nxaudio, apb);
+}
+
+static void player_complete_cb(unsigned long arg)
+{
+  FAR struct bailian_player *player = (FAR struct bailian_player *)(uintptr_t)arg;
+
+  if (player)
+    {
+      player->state = PLAYER_STATE_STOPPED;
+    }
+}
+
+static void player_user_cb(unsigned long arg, FAR struct audio_msg_s *msg,
+                           FAR bool *running)
+{
+  /* Not used */
+}
+
+static FAR void *player_thread(FAR void *arg)
+{
+  FAR struct bailian_player *player = (FAR struct bailian_player *)arg;
+  int i;
+
+  /* Pre-fill audio buffers before starting playback.
+   * Without this, the driver starts with no enqueued buffers,
+   * never triggers dequeue callbacks, and no audio plays.
+   * For stream mode the pipe read-end is blocking, so this
+   * will wait until bailian_player_write() pushes data. */
+
+  for (i = 0; i < player->nxaudio.abufnum; i++)
+    {
+      player_dequeue_cb((unsigned long)(uintptr_t)player,
+                        player->nxaudio.abufs[i]);
+    }
+
+  nxaudio_start(&player->nxaudio);
+  nxaudio_msgloop(&player->nxaudio, &g_player_cbs,
+                  (unsigned long)(uintptr_t)player);
+
+  player->state = PLAYER_STATE_STOPPED;
+  return NULL;
+}
+#endif
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+struct bailian_player *bailian_player_create_from_file(const char *filepath)
+{
+#ifdef CONFIG_AUDIOUTILS_NXAUDIO_LIB
+  struct bailian_player *player;
+  ssize_t read_ret;
+  int ret;
+  int i;
+
+  player = calloc(1, sizeof(struct bailian_player));
+  if (player == NULL)
+    {
+      return NULL;
+    }
+
+  player->state = PLAYER_STATE_IDLE;
+  player->mode = PLAYER_MODE_FILE;
+  player->fd = -1;
+  player->write_fd = -1;
+
+  player->fd = open(filepath, O_RDONLY);
+  if (player->fd < 0)
+    {
+      free(player);
+      return NULL;
+    }
+
+  read_ret = read(player->fd, &player->wav, sizeof(player->wav));
+  if (read_ret < (ssize_t)sizeof(player->wav))
+    {
+      close(player->fd);
+      free(player);
+      return NULL;
+    }
+
+  if (memcmp(player->wav.riff.chunk_id, "RIFF", 4) != 0 ||
+      memcmp(player->wav.riff.format, "WAVE", 4) != 0)
+    {
+      close(player->fd);
+      free(player);
+      return NULL;
+    }
+
+  ret = init_nxaudio(&player->nxaudio,
+                     (int)player->wav.fmt.sample_rate,
+                     (int)player->wav.fmt.bits_per_sample,
+                     (int)player->wav.fmt.num_channels);
+  if (ret < 0)
+    {
+      close(player->fd);
+      free(player);
+      return NULL;
+    }
+
+  for (i = 0; i < player->nxaudio.abufnum; i++)
+    {
+      player_dequeue_cb((unsigned long)(uintptr_t)player,
+                        player->nxaudio.abufs[i]);
+    }
+
+  player->state = PLAYER_STATE_INIT;
+
+  return player;
+#else
+  return NULL;
+#endif
+}
+
+int bailian_player_start(struct bailian_player *player)
+{
+#ifdef CONFIG_AUDIOUTILS_NXAUDIO_LIB
+  pthread_attr_t attr;
+  struct sched_param param;
+  int ret;
+
+  if (player == NULL)
+    {
+      return -EINVAL;
+    }
+
+  if (player->state != PLAYER_STATE_INIT &&
+      player->state != PLAYER_STATE_PAUSED)
+    {
+      return -EPERM;
+    }
+
+  player->state = PLAYER_STATE_PLAYING;
+
+  pthread_attr_init(&attr);
+  param.sched_priority = sched_get_priority_max(SCHED_FIFO) - 9;
+  pthread_attr_setschedparam(&attr, &param);
+  pthread_attr_setstacksize(&attr, 4096);
+
+  ret = pthread_create(&player->thread_id, &attr, player_thread, player);
+  pthread_attr_destroy(&attr);
+
+  if (ret != 0)
+    {
+      player->state = PLAYER_STATE_INIT;
+      return -ret;
+    }
+
+  pthread_setname_np(player->thread_id, "bailian_player");
+
+  return 0;
+#else
+  return -ENOSYS;
+#endif
+}
+
+int bailian_player_stop(struct bailian_player *player)
+{
+#ifdef CONFIG_AUDIOUTILS_NXAUDIO_LIB
+  if (player == NULL)
+    {
+      return -EINVAL;
+    }
+
+  /* Always call nxaudio_stop if thread is running, regardless of state.
+   * This ensures msgloop receives AUDIO_MSG_STOP and exits.
+   * Even if playback completed naturally (state=STOPPED), the thread
+   * may still be blocked on mq_receive().
+   */
+
+  if (player->thread_id > 0)
+    {
+      player->state = PLAYER_STATE_STOPPED;
+
+      if (player->write_fd >= 0)
+        {
+          close(player->write_fd);
+          player->write_fd = -1;
+        }
+
+      nxaudio_stop(&player->nxaudio);
+      pthread_join(player->thread_id, NULL);
+      player->thread_id = 0;
+    }
+
+  return 0;
+#else
+  return -ENOSYS;
+#endif
+}
+
+int bailian_player_set_volume(struct bailian_player *player, uint16_t volume)
+{
+#ifdef CONFIG_AUDIOUTILS_NXAUDIO_LIB
+  if (player == NULL)
+    {
+      return -EINVAL;
+    }
+
+  return nxaudio_setvolume(&player->nxaudio, volume);
+#else
+  return -ENOSYS;
+#endif
+}
+
+void bailian_player_destroy(struct bailian_player *player)
+{
+#ifdef CONFIG_AUDIOUTILS_NXAUDIO_LIB
+  if (player == NULL)
+    {
+      return;
+    }
+
+  bailian_player_stop(player);
+
+  if (player->fd >= 0)
+    {
+      close(player->fd);
+      player->fd = -1;
+    }
+
+  if (player->write_fd >= 0)
+    {
+      close(player->write_fd);
+      player->write_fd = -1;
+    }
+
+  fin_nxaudio(&player->nxaudio);
+  free(player);
+#endif
+}
+
+/* Legacy API - kept for compatibility */
+
+struct bailian_player *bailian_player_create(const char *dev, int sample_rate,
+                                             int channels, int bits_per_sample)
+{
+#ifdef CONFIG_AUDIOUTILS_NXAUDIO_LIB
+  struct bailian_player *player;
+  int pipefd[2];
+  int ret;
+
+  (void)dev;
+
+  player = calloc(1, sizeof(struct bailian_player));
+  if (player == NULL)
+    {
+      return NULL;
+    }
+
+  player->state = PLAYER_STATE_IDLE;
+  player->mode = PLAYER_MODE_STREAM;
+  player->fd = -1;
+  player->write_fd = -1;
+
+  ret = pipe(pipefd);
+  if (ret < 0)
+    {
+      free(player);
+      return NULL;
+    }
+
+  player->fd = pipefd[0];
+  player->write_fd = pipefd[1];
+
+  /* Set write end non-blocking so player_write won't block when
+   * nxaudio/virtio-snd can't consume fast enough.
+   * This prevents player_rb from filling up and stalling SDK recv. */
+  {
+    int flags = fcntl(player->write_fd, F_GETFL, 0);
+    if (flags >= 0)
+      {
+        fcntl(player->write_fd, F_SETFL, flags | O_NONBLOCK);
+      }
+  }
+  ret = init_nxaudio(&player->nxaudio, sample_rate, bits_per_sample, channels);
+  if (ret < 0)
+    {
+      close(player->fd);
+      close(player->write_fd);
+      free(player);
+      return NULL;
+    }
+
+  player->state = PLAYER_STATE_INIT;
+
+  return player;
+#else
+  return NULL;
+#endif
+}
+
+int bailian_player_open(struct bailian_player *player, const char *dev,
+                        int sample_rate, int channels, int bits_per_sample)
+{
+  return -ENOSYS;
+}
+
+ssize_t bailian_player_write(struct bailian_player *player,
+                             const uint8_t *buffer, size_t len)
+{
+#ifdef CONFIG_AUDIOUTILS_NXAUDIO_LIB
+  ssize_t written = 0;
+  ssize_t ret;
+
+  if (player == NULL || buffer == NULL)
+    {
+      return -EINVAL;
+    }
+
+  if (player->mode != PLAYER_MODE_STREAM)
+    {
+      return -EPERM;
+    }
+
+  if (player->write_fd < 0)
+    {
+      return -EBADF;
+    }
+
+  while (written < (ssize_t)len)
+    {
+      ret = write(player->write_fd, buffer + written, len - written);
+      if (ret < 0)
+        {
+          if (errno == EINTR)
+            {
+              continue;
+            }
+
+          if (errno == EAGAIN || errno == EWOULDBLOCK)
+            {
+              /* Pipe full — nxaudio can't consume fast enough.
+               * Drop remaining data to keep player_rb draining. */
+              break;
+            }
+
+          return written > 0 ? written : -errno;
+        }
+
+      if (ret == 0)
+        {
+          break;
+        }
+
+      written += ret;
+    }
+
+  return written;
+#else
+  return -ENOSYS;
+#endif
+}
+
+int bailian_player_is_stopped(struct bailian_player *player)
+{
+  if (player == NULL)
+    {
+      return 1;
+    }
+
+  return player->state == PLAYER_STATE_STOPPED;
+}
+
+void bailian_player_close(struct bailian_player *player)
+{
+  bailian_player_destroy(player);
+}

--- a/bailian/audio/recorder.c
+++ b/bailian/audio/recorder.c
@@ -1,0 +1,708 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <mqueue.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <nuttx/config.h>
+#include <nuttx/audio/audio.h>
+
+#ifdef CONFIG_SYSTEM_NXRECORDER
+#include <system/nxrecorder.h>
+#endif
+
+#define RECORDER_STATE_IDLE      0
+#define RECORDER_STATE_RECORDING 1
+#define RECORDER_STATE_PAUSED    2
+#define RECORDER_STATE_STOPPED   3
+
+#define RECORDER_NUM_BUFFERS     4
+#define RECORDER_BUFFER_SIZE     4096
+#define RECORDER_MQ_MAX_MSGS     8
+#define RECORDER_MQ_NAME_FMT     "/tmp/rec%lx"
+
+struct bailian_recorder
+{
+#ifdef CONFIG_SYSTEM_NXRECORDER
+  FAR struct nxrecorder_s *nxrec;
+#endif
+  int state;
+  int sample_rate;
+  int channels;
+  int bits_per_sample;
+  char filepath[128];
+
+  /* Streaming capture fields */
+
+  int dev_fd;
+  mqd_t mq;
+  char mqname[32];
+  FAR struct ap_buffer_s **buffers;
+  int nbuffers;
+
+  /* Partial buffer tracking for read() */
+
+  FAR struct ap_buffer_s *cur_apb;
+  uint32_t cur_offset;
+
+  /* File injection mode (bypass audio device) */
+
+  int file_mode;
+  int file_fd;
+};
+
+/* Forward declarations */
+
+static int recorder_stream_stop(struct bailian_recorder *rec);
+
+/****************************************************************************
+ * nxrecorder-based API (file recording)
+ ****************************************************************************/
+
+struct bailian_recorder *bailian_recorder_create(const char *dev,
+                                                 int sample_rate,
+                                                 int channels,
+                                                 int bits_per_sample)
+{
+#ifdef CONFIG_SYSTEM_NXRECORDER
+  struct bailian_recorder *rec;
+
+  rec = calloc(1, sizeof(*rec));
+  if (rec == NULL)
+    {
+      return NULL;
+    }
+
+  rec->nxrec = nxrecorder_create();
+  if (rec->nxrec == NULL)
+    {
+      printf("[bailian] Failed to create nxrecorder\n");
+      free(rec);
+      return NULL;
+    }
+
+  if (dev != NULL)
+    {
+      nxrecorder_setdevice(rec->nxrec, dev);
+    }
+
+  rec->sample_rate = sample_rate;
+  rec->channels = channels;
+  rec->bits_per_sample = bits_per_sample;
+  rec->state = RECORDER_STATE_IDLE;
+  rec->dev_fd = -1;
+  rec->mq = (mqd_t)-1;
+  rec->file_fd = -1;
+  rec->file_mode = 0;
+  rec->buffers = NULL;
+  rec->cur_apb = NULL;
+  rec->cur_offset = 0;
+
+  return rec;
+#else
+  printf("[bailian] SYSTEM_NXRECORDER not enabled\n");
+  return NULL;
+#endif
+}
+
+int bailian_recorder_start(struct bailian_recorder *rec, const char *filepath)
+{
+#ifdef CONFIG_SYSTEM_NXRECORDER
+  int ret;
+
+  if (rec == NULL || rec->nxrec == NULL || filepath == NULL)
+    {
+      return -EINVAL;
+    }
+
+  strncpy(rec->filepath, filepath, sizeof(rec->filepath) - 1);
+
+  ret = nxrecorder_recordinternal(rec->nxrec, filepath,
+                                  AUDIO_FMT_PCM, rec->channels,
+                                  rec->bits_per_sample, rec->sample_rate, 0);
+  if (ret < 0)
+    {
+      printf("[bailian] Failed to start recording: %d\n", ret);
+      return ret;
+    }
+
+  rec->state = RECORDER_STATE_RECORDING;
+  printf("[bailian] Recording started: %s\n", filepath);
+
+  return 0;
+#else
+  return -ENOSYS;
+#endif
+}
+
+int bailian_recorder_stop(struct bailian_recorder *rec)
+{
+#ifdef CONFIG_SYSTEM_NXRECORDER
+  if (rec == NULL || rec->nxrec == NULL)
+    {
+      return -EINVAL;
+    }
+
+  if (rec->state != RECORDER_STATE_RECORDING &&
+      rec->state != RECORDER_STATE_PAUSED)
+    {
+      return 0;
+    }
+
+#ifndef CONFIG_AUDIO_EXCLUDE_STOP
+  nxrecorder_stop(rec->nxrec);
+#endif
+
+  rec->state = RECORDER_STATE_STOPPED;
+  printf("[bailian] Recording stopped\n");
+
+  return 0;
+#else
+  return -ENOSYS;
+#endif
+}
+
+int bailian_recorder_pause(struct bailian_recorder *rec)
+{
+#ifdef CONFIG_SYSTEM_NXRECORDER
+  if (rec == NULL || rec->nxrec == NULL)
+    {
+      return -EINVAL;
+    }
+
+  if (rec->state != RECORDER_STATE_RECORDING)
+    {
+      return -EPERM;
+    }
+
+#ifndef CONFIG_AUDIO_EXCLUDE_PAUSE_RESUME
+  nxrecorder_pause(rec->nxrec);
+#endif
+
+  rec->state = RECORDER_STATE_PAUSED;
+  return 0;
+#else
+  return -ENOSYS;
+#endif
+}
+
+int bailian_recorder_resume(struct bailian_recorder *rec)
+{
+#ifdef CONFIG_SYSTEM_NXRECORDER
+  if (rec == NULL || rec->nxrec == NULL)
+    {
+      return -EINVAL;
+    }
+
+  if (rec->state != RECORDER_STATE_PAUSED)
+    {
+      return -EPERM;
+    }
+
+#ifndef CONFIG_AUDIO_EXCLUDE_PAUSE_RESUME
+  nxrecorder_resume(rec->nxrec);
+#endif
+
+  rec->state = RECORDER_STATE_RECORDING;
+  return 0;
+#else
+  return -ENOSYS;
+#endif
+}
+
+void bailian_recorder_destroy(struct bailian_recorder *rec)
+{
+#ifdef CONFIG_SYSTEM_NXRECORDER
+  if (rec == NULL)
+    {
+      return;
+    }
+
+  /* Stop streaming capture if active */
+
+  if (rec->dev_fd >= 0)
+    {
+      recorder_stream_stop(rec);
+    }
+
+  bailian_recorder_stop(rec);
+
+  if (rec->nxrec != NULL)
+    {
+      nxrecorder_release(rec->nxrec);
+      rec->nxrec = NULL;
+    }
+
+  free(rec);
+#endif
+}
+
+/****************************************************************************
+ * Streaming capture API (open/read/close for SDK real-time audio)
+ ****************************************************************************/
+
+int bailian_recorder_open(struct bailian_recorder *rec, const char *dev,
+                          int sample_rate, int channels, int bits_per_sample)
+{
+  struct audio_caps_desc_s cap_desc;
+  struct audio_buf_desc_s buf_desc;
+  struct ap_buffer_info_s buf_info;
+  struct mq_attr attr;
+  int ret;
+  int i;
+
+  if (rec == NULL)
+    {
+      return -EINVAL;
+    }
+
+  if (rec->dev_fd >= 0 || rec->file_fd >= 0)
+    {
+      return -EBUSY;
+    }
+
+  /* Use provided dev or fall back to stored device path */
+
+  if (dev == NULL)
+    {
+      dev = CONFIG_AI_BAILIAN_RECORDER_DEV;
+    }
+
+  /* Check if dev is a PCM file (file injection mode) */
+
+  size_t devlen = strlen(dev);
+  if (devlen > 4 && strcmp(dev + devlen - 4, ".pcm") == 0)
+    {
+      rec->file_fd = open(dev, O_RDONLY);
+      if (rec->file_fd < 0)
+        {
+          printf("[bailian] recorder: failed to open file %s: %d\n",
+                 dev, errno);
+          return -errno;
+        }
+
+      rec->file_mode = 1;
+      rec->sample_rate = sample_rate ? sample_rate : 24000;
+      rec->channels = channels ? channels : 1;
+      rec->bits_per_sample = bits_per_sample ? bits_per_sample : 16;
+      rec->state = RECORDER_STATE_RECORDING;
+      printf("[bailian] recorder: FILE MODE from %s (%dHz %dch %dbit)\n",
+             dev, rec->sample_rate, rec->channels, rec->bits_per_sample);
+      return OK;
+    }
+
+  /* Warmup: QEMU virtio-snd PA capture needs a dummy open/start cycle
+   * to activate the PulseAudio source (first open returns zeros). */
+
+  {
+    int warmup_fd = open(dev, O_RDWR | O_CLOEXEC);
+    if (warmup_fd >= 0)
+      {
+        struct audio_caps_desc_s wcap;
+        memset(&wcap, 0, sizeof(wcap));
+        wcap.caps.ac_len = sizeof(struct audio_caps_s);
+        wcap.caps.ac_type = AUDIO_TYPE_INPUT;
+        wcap.caps.ac_channels = channels ? channels : 1;
+        wcap.caps.ac_controls.hw[0] = sample_rate ? sample_rate : 24000;
+        wcap.caps.ac_controls.b[3] = sample_rate >> 16;
+        wcap.caps.ac_controls.b[2] = bits_per_sample ? bits_per_sample : 16;
+        wcap.caps.ac_subtype = AUDIO_FMT_PCM;
+
+        if (ioctl(warmup_fd, AUDIOIOC_RESERVE, 0) == 0)
+          {
+            ioctl(warmup_fd, AUDIOIOC_CONFIGURE, (uintptr_t)&wcap);
+            ioctl(warmup_fd, AUDIOIOC_START, 0);
+            usleep(200000); /* 200ms - let PA source activate */
+            ioctl(warmup_fd, AUDIOIOC_STOP, 0);
+            ioctl(warmup_fd, AUDIOIOC_RELEASE, 0);
+          }
+
+        close(warmup_fd);
+        usleep(100000); /* 100ms - let device settle */
+        printf("[bailian] recorder: warmup cycle done\n");
+      }
+  }
+
+  /* Open the audio capture device */
+
+  rec->dev_fd = open(dev, O_RDWR | O_CLOEXEC);
+  if (rec->dev_fd < 0)
+    {
+      printf("[bailian] recorder: failed to open %s: %d\n", dev, errno);
+      return -errno;
+    }
+
+  /* Reserve the device */
+
+  ret = ioctl(rec->dev_fd, AUDIOIOC_RESERVE, 0);
+  if (ret < 0)
+    {
+      printf("[bailian] recorder: RESERVE failed: %d\n", errno);
+      goto err_close;
+    }
+
+  /* Configure for capture */
+
+  memset(&cap_desc, 0, sizeof(cap_desc));
+  cap_desc.caps.ac_len = sizeof(struct audio_caps_s);
+  cap_desc.caps.ac_type = AUDIO_TYPE_INPUT;
+  cap_desc.caps.ac_channels = channels ? channels : 1;
+  cap_desc.caps.ac_controls.hw[0] = sample_rate ? sample_rate : 16000;
+  cap_desc.caps.ac_controls.b[3] = sample_rate >> 16;
+  cap_desc.caps.ac_controls.b[2] = bits_per_sample ? bits_per_sample : 16;
+  cap_desc.caps.ac_subtype = AUDIO_FMT_PCM;
+
+  ret = ioctl(rec->dev_fd, AUDIOIOC_CONFIGURE, (uintptr_t)&cap_desc);
+  if (ret < 0)
+    {
+      printf("[bailian] recorder: CONFIGURE failed: %d\n", errno);
+      goto err_release;
+    }
+
+  /* Query buffer info */
+
+  if (ioctl(rec->dev_fd, AUDIOIOC_GETBUFFERINFO,
+            (uintptr_t)&buf_info) != OK)
+    {
+      buf_info.buffer_size = RECORDER_BUFFER_SIZE;
+      buf_info.nbuffers = RECORDER_NUM_BUFFERS;
+    }
+
+  rec->nbuffers = buf_info.nbuffers;
+
+  /* Allocate buffer pointer array */
+
+  rec->buffers = calloc(rec->nbuffers, sizeof(FAR struct ap_buffer_s *));
+  if (rec->buffers == NULL)
+    {
+      printf("[bailian] recorder: buffer array alloc failed\n");
+      ret = -ENOMEM;
+      goto err_release;
+    }
+
+  /* Allocate audio buffers */
+
+  for (i = 0; i < rec->nbuffers; i++)
+    {
+      buf_desc.numbytes = buf_info.buffer_size;
+      buf_desc.u.pbuffer = &rec->buffers[i];
+
+      ret = ioctl(rec->dev_fd, AUDIOIOC_ALLOCBUFFER,
+                  (uintptr_t)&buf_desc);
+      if (ret != sizeof(buf_desc))
+        {
+          printf("[bailian] recorder: ALLOCBUFFER %d failed\n", i);
+          ret = -ENOMEM;
+          goto err_free_bufs;
+        }
+    }
+
+  /* Create message queue */
+
+  snprintf(rec->mqname, sizeof(rec->mqname), RECORDER_MQ_NAME_FMT,
+           (unsigned long)((uintptr_t)rec));
+
+  attr.mq_maxmsg = rec->nbuffers + RECORDER_MQ_MAX_MSGS;
+  attr.mq_msgsize = sizeof(struct audio_msg_s);
+  attr.mq_curmsgs = 0;
+  attr.mq_flags = 0;
+
+  rec->mq = mq_open(rec->mqname, O_RDWR | O_CREAT, 0644, &attr);
+  if (rec->mq == (mqd_t)-1)
+    {
+      printf("[bailian] recorder: mq_open failed: %d\n", errno);
+      ret = -errno;
+      goto err_free_bufs;
+    }
+
+  /* Register message queue with audio device */
+
+  ioctl(rec->dev_fd, AUDIOIOC_REGISTERMQ, (uintptr_t)rec->mq);
+
+  /* Enqueue all buffers for capture */
+
+  for (i = 0; i < rec->nbuffers; i++)
+    {
+      struct audio_buf_desc_s enq;
+
+      rec->buffers[i]->nbytes = rec->buffers[i]->nmaxbytes;
+      enq.numbytes = rec->buffers[i]->nbytes;
+      enq.u.buffer = rec->buffers[i];
+
+      ret = ioctl(rec->dev_fd, AUDIOIOC_ENQUEUEBUFFER,
+                  (uintptr_t)&enq);
+      if (ret < 0)
+        {
+          printf("[bailian] recorder: ENQUEUEBUFFER %d failed: %d\n",
+                 i, errno);
+          goto err_mq;
+        }
+    }
+
+  /* Start capture */
+
+  ret = ioctl(rec->dev_fd, AUDIOIOC_START, 0);
+  if (ret < 0)
+    {
+      printf("[bailian] recorder: START failed: %d\n", errno);
+      goto err_mq;
+    }
+
+  rec->state = RECORDER_STATE_RECORDING;
+  rec->cur_apb = NULL;
+  rec->cur_offset = 0;
+
+  printf("[bailian] recorder: streaming started (%dHz %dch %dbit)\n",
+         sample_rate, channels, bits_per_sample);
+  return 0;
+
+err_mq:
+  ioctl(rec->dev_fd, AUDIOIOC_UNREGISTERMQ, (uintptr_t)rec->mq);
+  mq_close(rec->mq);
+  mq_unlink(rec->mqname);
+  rec->mq = (mqd_t)-1;
+
+err_free_bufs:
+  if (rec->buffers != NULL)
+    {
+      for (i = 0; i < rec->nbuffers; i++)
+        {
+          if (rec->buffers[i] != NULL)
+            {
+              buf_desc.u.buffer = rec->buffers[i];
+              ioctl(rec->dev_fd, AUDIOIOC_FREEBUFFER,
+                    (uintptr_t)&buf_desc);
+            }
+        }
+
+      free(rec->buffers);
+      rec->buffers = NULL;
+    }
+
+err_release:
+  ioctl(rec->dev_fd, AUDIOIOC_RELEASE, 0);
+
+err_close:
+  close(rec->dev_fd);
+  rec->dev_fd = -1;
+  return ret;
+}
+
+ssize_t bailian_recorder_read(struct bailian_recorder *rec, uint8_t *buffer,
+                              size_t len)
+{
+  struct audio_msg_s msg;
+  unsigned int prio;
+  size_t copied = 0;
+  if (rec == NULL || buffer == NULL || len == 0)
+    {
+      return -EINVAL;
+    }
+  if (rec->state != RECORDER_STATE_RECORDING)
+    {
+      return -ENOSYS;
+    }
+  /* File injection mode: read from PCM file with pacing */
+  if (rec->file_mode)
+    {
+      if (rec->file_fd < 0)
+        {
+          return -ENOSYS;
+        }
+      ssize_t n = read(rec->file_fd, buffer, len);
+      if (n <= 0)
+        {
+          /* EOF or error - loop back to start */
+          lseek(rec->file_fd, 0, SEEK_SET);
+          n = read(rec->file_fd, buffer, len);
+          if (n <= 0)
+            {
+              return 0;
+            }
+        }
+      /* Pace to real-time: len bytes at sample_rate * channels * (bps/8) */
+      int bytes_per_sec = rec->sample_rate * rec->channels *
+                          (rec->bits_per_sample / 8);
+      if (bytes_per_sec > 0)
+        {
+          useconds_t us = (useconds_t)((uint64_t)n * 1000000 / bytes_per_sec);
+          usleep(us);
+        }
+      return n;
+    }
+  /* Audio device mode */
+  if (rec->dev_fd < 0)
+    {
+      return -ENOSYS;
+    }
+
+  while (copied < len)
+    {
+      /* If we have leftover data from a previous buffer, use it */
+
+      if (rec->cur_apb != NULL)
+        {
+          uint32_t avail = rec->cur_apb->nbytes - rec->cur_offset;
+          uint32_t tocopy = (len - copied) < avail ?
+                            (len - copied) : avail;
+
+          memcpy(buffer + copied, rec->cur_apb->samp + rec->cur_offset,
+                 tocopy);
+          copied += tocopy;
+          rec->cur_offset += tocopy;
+
+          /* If buffer fully consumed, re-enqueue it */
+
+          if (rec->cur_offset >= rec->cur_apb->nbytes)
+            {
+              struct audio_buf_desc_s enq;
+
+              rec->cur_apb->nbytes = rec->cur_apb->nmaxbytes;
+              enq.numbytes = rec->cur_apb->nbytes;
+              enq.u.buffer = rec->cur_apb;
+
+              ioctl(rec->dev_fd, AUDIOIOC_ENQUEUEBUFFER,
+                    (uintptr_t)&enq);
+
+              rec->cur_apb = NULL;
+              rec->cur_offset = 0;
+            }
+
+          continue;
+        }
+
+      /* Wait for next filled buffer from audio driver */
+
+      ssize_t sz = mq_receive(rec->mq, (FAR char *)&msg,
+                              sizeof(msg), &prio);
+      if (sz != sizeof(msg))
+        {
+          if (copied > 0)
+            {
+              return copied;
+            }
+
+          return -errno;
+        }
+
+      switch (msg.msg_id)
+        {
+          case AUDIO_MSG_DEQUEUE:
+            rec->cur_apb = (FAR struct ap_buffer_s *)msg.u.ptr;
+            rec->cur_offset = 0;
+            break;
+
+          case AUDIO_MSG_COMPLETE:
+            rec->state = RECORDER_STATE_STOPPED;
+            return copied > 0 ? copied : 0;
+
+          default:
+            break;
+        }
+    }
+
+  return copied;
+}
+
+static int recorder_stream_stop(struct bailian_recorder *rec)
+{
+  struct audio_buf_desc_s buf_desc;
+  struct audio_msg_s msg;
+  unsigned int prio;
+  struct timespec ts;
+  int i;
+
+  if (rec->dev_fd < 0)
+    {
+      return 0;
+    }
+
+  /* Stop the audio device */
+
+  ioctl(rec->dev_fd, AUDIOIOC_STOP, 0);
+
+  /* Drain remaining messages */
+
+  clock_gettime(CLOCK_REALTIME, &ts);
+  ts.tv_nsec += 100000000; /* 100ms timeout */
+  if (ts.tv_nsec >= 1000000000)
+    {
+      ts.tv_sec++;
+      ts.tv_nsec -= 1000000000;
+    }
+
+  while (rec->mq != (mqd_t)-1)
+    {
+      if (mq_timedreceive(rec->mq, (FAR char *)&msg,
+                          sizeof(msg), &prio, &ts) != sizeof(msg))
+        {
+          break;
+        }
+    }
+
+  /* Free audio buffers */
+
+  if (rec->buffers != NULL)
+    {
+      for (i = 0; i < rec->nbuffers; i++)
+        {
+          if (rec->buffers[i] != NULL)
+            {
+              buf_desc.u.buffer = rec->buffers[i];
+              ioctl(rec->dev_fd, AUDIOIOC_FREEBUFFER,
+                    (uintptr_t)&buf_desc);
+            }
+        }
+
+      free(rec->buffers);
+      rec->buffers = NULL;
+    }
+
+  /* Cleanup message queue */
+
+  if (rec->mq != (mqd_t)-1)
+    {
+      ioctl(rec->dev_fd, AUDIOIOC_UNREGISTERMQ, (uintptr_t)rec->mq);
+      mq_close(rec->mq);
+      mq_unlink(rec->mqname);
+      rec->mq = (mqd_t)-1;
+    }
+
+  /* Release and close device */
+
+  ioctl(rec->dev_fd, AUDIOIOC_RELEASE, 0);
+  close(rec->dev_fd);
+  rec->dev_fd = -1;
+
+  rec->cur_apb = NULL;
+  rec->cur_offset = 0;
+  rec->state = RECORDER_STATE_IDLE;
+
+  printf("[bailian] recorder: streaming stopped\n");
+  return 0;
+}
+
+void bailian_recorder_close(struct bailian_recorder *rec)
+{
+  if (rec == NULL)
+    {
+      return;
+    }
+  /* File injection mode cleanup */
+  if (rec->file_mode)
+    {
+      if (rec->file_fd >= 0)
+        {
+          close(rec->file_fd);
+          rec->file_fd = -1;
+        }
+      rec->file_mode = 0;
+      rec->state = RECORDER_STATE_IDLE;
+      printf("[bailian] recorder: file mode stopped\n");
+      return;
+    }
+  recorder_stream_stop(rec);
+}

--- a/bailian/bailian_main.c
+++ b/bailian/bailian_main.c
@@ -1,0 +1,803 @@
+#include <nuttx/config.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "c_mmi.h"
+#include "c_mmi_config.h"
+#include "c_mmi_msg.h"
+#include "c_mmi_storage.h"
+/* lib_c_license.h removed - using pay-as-you-go mode */
+#include "c_utils/hal_util_mem.h"
+#include "c_utils/hal_util_time.h"
+#include "c_utils/hal_util_random.h"
+#include "c_utils/hal_util_mutex.h"
+#include "c_utils/hal_util_storage.h"
+#include "qwen_test.h"
+
+#ifndef CONFIG_AI_BAILIAN_WORKSPACE_ID
+#define CONFIG_AI_BAILIAN_WORKSPACE_ID ""
+#endif
+
+#ifndef CONFIG_AI_BAILIAN_APP_ID
+#define CONFIG_AI_BAILIAN_APP_ID ""
+#endif
+
+#ifndef CONFIG_AI_BAILIAN_API_KEY
+#define CONFIG_AI_BAILIAN_API_KEY ""
+#endif
+
+/* License mode configs removed - using pay-as-you-go mode */
+
+#ifndef CONFIG_AI_BAILIAN_RECORDER_DEV
+#define CONFIG_AI_BAILIAN_RECORDER_DEV "/dev/pcm_in0"
+#endif
+
+#ifndef CONFIG_AI_BAILIAN_PLAYER_DEV
+#define CONFIG_AI_BAILIAN_PLAYER_DEV "/dev/pcm_out0"
+#endif
+
+struct bailian_recorder;
+struct bailian_player;
+struct bailian_ws_client;
+
+/* License mode HTTP functions removed - not needed for pay-as-you-go mode */
+
+struct bailian_recorder *bailian_recorder_create(const char *dev,
+                                                 int sample_rate,
+                                                 int channels,
+                                                 int bits_per_sample);
+ssize_t bailian_recorder_read(struct bailian_recorder *rec, uint8_t *buffer,
+                              size_t len);
+void bailian_recorder_destroy(struct bailian_recorder *rec);
+int bailian_recorder_open(struct bailian_recorder *rec, const char *dev,
+                          int sample_rate, int channels, int bits_per_sample);
+void bailian_recorder_close(struct bailian_recorder *rec);
+
+struct bailian_player *bailian_player_create(const char *dev, int sample_rate,
+                                             int channels, int bits_per_sample);
+struct bailian_player *bailian_player_create_from_file(const char *filepath);
+int bailian_player_start(struct bailian_player *player);
+int bailian_player_stop(struct bailian_player *player);
+int bailian_player_is_stopped(struct bailian_player *player);
+ssize_t bailian_player_write(struct bailian_player *player,
+                             const uint8_t *buffer, size_t len);
+void bailian_player_destroy(struct bailian_player *player);
+
+int bailian_ws_connect(const char *url, const char *extra_headers,
+                       int timeout_ms, struct bailian_ws_client **out);
+void bailian_ws_dns_prefetch(const char *host, uint16_t port);
+int bailian_ws_send(struct bailian_ws_client *client, uint8_t opcode,
+                    const uint8_t *data, size_t len);
+int bailian_ws_recv(struct bailian_ws_client *client, uint8_t *opcode,
+                    uint8_t *data, size_t len, int timeout_ms);
+void bailian_ws_close(struct bailian_ws_client *client);
+
+struct bailian_app_s
+{
+  struct bailian_recorder *recorder;
+  struct bailian_player *player;
+  pthread_t recorder_thread;
+  pthread_t player_thread;
+  pthread_t ws_thread;
+  volatile bool running;
+  volatile bool recording;
+  volatile bool playing;
+  volatile bool speech_started;  /* SDK event: ready to send audio */
+  volatile bool stop_requested;  /* user pressed 's' */
+  volatile int64_t record_start_ms; /* timestamp when recording started */
+
+  /* Our own audio buffer — SDK's recorder_rb gets reset internally */
+  pthread_mutex_t audio_mutex;
+  uint8_t *audio_buf;
+  uint32_t audio_buf_size;
+  volatile uint32_t audio_write_pos;
+  volatile uint32_t audio_read_pos;
+  volatile bool audio_done;  /* recorder finished writing */
+};
+
+static struct bailian_app_s g_bailian;
+
+static int64_t bailian_now_ms(void)
+{
+  struct timespec ts;
+
+  if (clock_gettime(CLOCK_REALTIME, &ts) != 0)
+    {
+      return 0;
+    }
+
+  return (int64_t)ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+}
+
+static void *bailian_recorder_loop(void *arg)
+{
+  struct bailian_app_s *app = (struct bailian_app_s *)arg;
+  uint8_t buffer[960];
+  uint32_t total_bytes = 0;
+  uint32_t read_count = 0;
+
+  while (app->running)
+    {
+      if (!app->recording)
+        {
+          if (total_bytes > 0)
+            {
+              printf("[bailian] recorder: sent total %u bytes in %u reads\n",
+                     total_bytes, read_count);
+              total_bytes = 0;
+              read_count = 0;
+              app->audio_done = true;
+            }
+          usleep(10000);
+          continue;
+        }
+
+      ssize_t ret = bailian_recorder_read(app->recorder, buffer, sizeof(buffer));
+      if (ret > 0)
+        {
+          int16_t *samples = (int16_t *)buffer;
+          int nsamples = ret / 2;
+          int64_t sum_sq = 0;
+          int16_t peak = 0;
+          for (int i = 0; i < nsamples; i++)
+            {
+              int16_t s = samples[i];
+              sum_sq += (int64_t)s * s;
+              if (s < 0) s = -s;
+              if (s > peak) peak = s;
+            }
+          if (read_count % 50 == 0)
+            {
+              printf("[bailian] audio: read=%zd rms=%u peak=%d total=%u\n",
+                     ret, (uint32_t)(sum_sq / nsamples),
+                     (int)peak, total_bytes);
+            }
+          total_bytes += ret;
+          read_count++;
+          /* Feed audio to SDK so it can send binary frames via
+           * c_mmi_get_send_data() after SpeechStarted */
+          c_mmi_put_recorder_data(buffer, ret);
+          /* Also copy to our own buffer as backup */
+          pthread_mutex_lock(&app->audio_mutex);
+          uint32_t wp = app->audio_write_pos;
+          if (wp + (uint32_t)ret <= app->audio_buf_size)
+            {
+              memcpy(app->audio_buf + wp, buffer, ret);
+              app->audio_write_pos = wp + (uint32_t)ret;
+            }
+          pthread_mutex_unlock(&app->audio_mutex);
+        }
+      else
+        {
+          usleep(5000);
+        }
+    }
+  return NULL;
+}
+
+static void *bailian_player_loop(void *arg)
+{
+  struct bailian_app_s *app = (struct bailian_app_s *)arg;
+  uint8_t buffer[8192];  /* 8KB per official doc recommendation */
+  uint8_t upsample_buf[16384]; /* 2x for 24kHz→48kHz upsampling */
+  bool player_active = false;
+
+  while (app->running)
+    {
+      /* Always try to read from player_rb — don't gate on playing flag.
+       * SDK writes TTS audio into player_rb from the ws recv path.
+       * If we don't consume it, player_rb fills up and SDK blocks,
+       * which stalls the ws_loop recv and causes heartbeat timeout. */
+      uint32_t got = c_mmi_get_player_data(buffer, sizeof(buffer));
+      if (got > 0)
+        {
+          if (!player_active)
+            {
+              printf("[PLAYER] TTS audio started, got %u bytes\n",
+                     (unsigned)got);
+              bailian_player_start(app->player);
+              player_active = true;
+            }
+
+          /* Upsample 24kHz→48kHz: duplicate each 16-bit sample */
+          {
+            const int16_t *src = (const int16_t *)buffer;
+            int16_t *dst = (int16_t *)upsample_buf;
+            uint32_t nsamples = got / 2;
+            uint32_t i;
+            for (i = 0; i < nsamples; i++)
+              {
+                dst[i * 2]     = src[i];
+                dst[i * 2 + 1] = src[i];
+              }
+            bailian_player_write(app->player, upsample_buf, got * 2);
+          }
+        }
+      else if (player_active && c_mmi_audio_recv_all())
+        {
+          printf("[PLAYER] TTS audio finished\n");
+          bailian_player_stop(app->player);
+          player_active = false;
+        }
+      else
+        {
+          usleep(5000);
+        }
+    }
+
+  if (player_active)
+    {
+      bailian_player_stop(app->player);
+    }
+  return NULL;
+}
+
+static void *bailian_ws_loop(void *arg)
+{
+  struct bailian_app_s *app = (struct bailian_app_s *)arg;
+  struct bailian_ws_client *client = NULL;
+  char url[256];
+  char headers[256];
+  uint32_t ws_send_count = 0;
+  uint32_t ws_bin_bytes = 0;
+  uint32_t ws_bin_frames = 0;
+
+  /* Separate recv buffer on heap — TTS binary frames can be >> 8KB */
+  const size_t recv_buf_size = 64 * 1024;
+  uint8_t *recv_buf = malloc(recv_buf_size);
+  if (recv_buf == NULL)
+    {
+      printf("[WS] Failed to allocate recv buffer\n");
+      return NULL;
+    }
+  printf("[WS] Thread started\n");
+  fflush(stdout);
+  while (app->running)
+    {
+      if (client == NULL)
+        {
+          char *host = c_mmi_get_wss_host();
+          char *port = c_mmi_get_wss_port();
+          char *api = c_mmi_get_wss_api();
+          char *header = c_mmi_get_wss_header();
+
+          if (host == NULL || port == NULL || api == NULL)
+            {
+              usleep(100000);
+              continue;
+            }
+
+          snprintf(url, sizeof(url), "wss://%s:%s%s", host, port, api);
+          if (header != NULL && header[0] != '\0')
+            {
+              snprintf(headers, sizeof(headers), "%s\r\n", header);
+            }
+          else
+            {
+              headers[0] = '\0';
+            }
+
+          printf("[WS] Connecting to %s\n", url);
+          if (bailian_ws_connect(url, headers, 5000, &client) != 0)
+            {
+              client = NULL;
+              usleep(200000);
+              continue;
+            }
+        }
+
+      /* 1. Send SDK text commands (run-task, SendSpeech, HeartBeat etc) */
+
+      uint8_t opcode = 0;
+      uint8_t buffer[8192];
+      uint32_t size = c_mmi_get_send_data(&opcode, buffer, sizeof(buffer));
+      if (size > 0)
+        {
+          if (opcode == WEBSOCKET_OPCODE_BINARY)
+            {
+              ws_bin_bytes += size;
+              ws_bin_frames++;
+              if (ws_bin_frames % 100 == 0)
+                {
+                  printf("[WS] SDK binary #%u size=%u total=%u\n",
+                         ws_bin_frames, (unsigned)size, ws_bin_bytes);
+                }
+            }
+          else
+            {
+              printf("[WS] text #%u size=%u: %.*s\n",
+                     ws_send_count, (unsigned)size,
+                     (int)(size > 512 ? 512 : size), (char *)buffer);
+            }
+          ws_send_count++;
+          bailian_ws_send(client, opcode, buffer, size);
+        }
+
+      /* 2. Stream audio binary from our own buffer.
+       *    Trigger: app->speech_started (set by SDK event callback).
+       *    Send up to 8 frames per loop iteration. */
+      if (app->speech_started && client != NULL)
+        {
+          int burst;
+          for (burst = 0; burst < 8; burst++)
+            {
+              pthread_mutex_lock(&app->audio_mutex);
+              uint32_t rp = app->audio_read_pos;
+              uint32_t wp = app->audio_write_pos;
+              uint32_t avail = (wp > rp) ? (wp - rp) : 0;
+              if (avail > 0)
+                {
+                  uint32_t chunk = avail;
+                  if (chunk > sizeof(buffer)) chunk = sizeof(buffer);
+                  memcpy(buffer, app->audio_buf + rp, chunk);
+                  app->audio_read_pos = rp + chunk;
+                  pthread_mutex_unlock(&app->audio_mutex);
+                  ws_bin_bytes += chunk;
+                  ws_bin_frames++;
+                  if (ws_bin_frames <= 3 || ws_bin_frames % 10 == 0)
+                    {
+                      printf("[WS] binary #%u size=%u total=%u\n",
+                             ws_bin_frames, (unsigned)chunk,
+                             ws_bin_bytes);
+                    }
+                  bailian_ws_send(client, WEBSOCKET_OPCODE_BINARY,
+                                  buffer, chunk);
+                }
+              else
+                {
+                  pthread_mutex_unlock(&app->audio_mutex);
+                  if (app->audio_done && app->stop_requested)
+                    {
+                      printf("[WS] audio drained, calling speech_end\n");
+                      c_mmi_speech_end();
+                      bailian_recorder_close(app->recorder);
+                      app->recording = false;
+                      app->speech_started = false;
+                      app->stop_requested = false;
+                      app->audio_done = false;
+                      ws_bin_frames = 0;
+                      ws_bin_bytes = 0;
+                    }
+                  break;
+                }
+            }
+        }
+
+      /* 3. Receive from server */
+
+      memset(recv_buf, 0, 256);
+      int ret = bailian_ws_recv(client, &opcode, recv_buf, recv_buf_size, 50);
+      if (ret > 0)
+        {
+          if (opcode == WEBSOCKET_OPCODE_TEXT && ret < 1024)
+            {
+              printf("[WS] recv text: %.*s\n", ret, (char *)recv_buf);
+            }
+          else if (opcode == WEBSOCKET_OPCODE_BINARY)
+            {
+              printf("[WS] recv binary size=%d\n", ret);
+            }
+
+          c_mmi_analyze_recv_data(opcode, recv_buf, (uint32_t)ret);
+          if (opcode == WEBSOCKET_OPCODE_DISCONNECT)
+            {
+              bailian_ws_close(client);
+              client = NULL;
+            }
+        }
+      else if (ret < 0)
+        {
+          printf("[WS] recv error=%d, reconnecting\n", ret);
+          bailian_ws_close(client);
+          client = NULL;
+        }
+    }
+
+  if (client != NULL)
+    {
+      bailian_ws_close(client);
+    }
+
+  free(recv_buf);
+  return NULL;
+}
+
+static int bailian_event_cb(uint32_t event, void *param)
+{
+  (void)param;
+
+  switch (event)
+    {
+      case C_MMI_EVENT_USER_CONFIG:
+        {
+          /* Reset dialog ID per official doc */
+          c_mmi_reset_dialog_id();
+          mmi_user_config_t config = C_MMI_CONFIG_DEFAULT();
+          config.evt_cb = bailian_event_cb;
+          config.work_mode = C_MMI_MODE_PUSH2TALK;
+          config.text_mode = C_MMI_TEXT_MODE_BOTH;
+          config.upstream_mode = C_MMI_STREAM_MODE_PCM;
+          config.downstream_mode = C_MMI_STREAM_MODE_PCM;
+          config.us_sample_rate = 24000;
+          config.ds_sample_rate = 24000;
+          config.recorder_rb_size = 512 * 1024;
+          config.player_rb_size = 64 * 1024;
+          config.user_id = "openvela_user";
+          strncpy(config.voice_id, "longxiaochun_v3",
+                  sizeof(config.voice_id) - 1);
+          strncpy(config.story_voice_id, "longxiaochun_v3",
+                  sizeof(config.story_voice_id) - 1);
+          c_mmi_config(&config);
+        }
+        break;
+      case C_MMI_EVENT_DATA_INIT:
+        /* SDK initialized, WSS connection will be established in ws_loop */
+        printf("[BAILIAN] SDK data init done, ready for WSS\n");
+        break;
+      case C_MMI_EVENT_SPEECH_START:
+      case C_MMI_EVENT_SPEECH_RESTART:
+        g_bailian.speech_started = true;
+        printf("[BAILIAN] event: SpeechStart/Restart\n");
+        break;
+        break;
+      case C_MMI_EVENT_SPEECH_PREPARE:
+        g_bailian.speech_started = false;
+        printf("[BAILIAN] event: SpeechPrepare\n");
+        break;
+      case C_MMI_EVENT_TTS_START:
+        g_bailian.playing = true;
+        break;
+      case C_MMI_EVENT_TTS_END:
+        g_bailian.playing = false;
+        break;
+      default:
+        break;
+    }
+
+  return 0;
+}
+
+/* bailian_register_and_login() removed - not needed for pay-as-you-go mode */
+
+static int bailian_init_app(void)
+{
+  g_bailian.recorder = bailian_recorder_create(CONFIG_AI_BAILIAN_RECORDER_DEV,
+                                               24000, 1, 16);
+  g_bailian.player = bailian_player_create(CONFIG_AI_BAILIAN_PLAYER_DEV,
+                                           48000, 1, 16);
+  if (g_bailian.recorder == NULL || g_bailian.player == NULL)
+    {
+      return -ENODEV;
+    }
+  /* Allocate our own audio buffer (512KB) */
+  g_bailian.audio_buf_size = 512 * 1024;
+  g_bailian.audio_buf = malloc(g_bailian.audio_buf_size);
+  if (g_bailian.audio_buf == NULL)
+    {
+      return -ENOMEM;
+    }
+  g_bailian.audio_write_pos = 0;
+  g_bailian.audio_read_pos = 0;
+  g_bailian.audio_done = false;
+  pthread_mutex_init(&g_bailian.audio_mutex, NULL);
+  g_bailian.running = true;
+  /* Use large stack for all threads - SDK internal processing needs it */
+  pthread_attr_t attr;
+  pthread_attr_init(&attr);
+  pthread_attr_setstacksize(&attr, 32768);
+  pthread_create(&g_bailian.recorder_thread, &attr, bailian_recorder_loop,
+                 &g_bailian);
+  pthread_create(&g_bailian.player_thread, &attr, bailian_player_loop,
+                 &g_bailian);
+  pthread_create(&g_bailian.ws_thread, &attr, bailian_ws_loop, &g_bailian);
+  pthread_attr_destroy(&attr);
+  return 0;
+}
+
+static void bailian_deinit_app(void)
+{
+  g_bailian.running = false;
+  pthread_join(g_bailian.recorder_thread, NULL);
+  pthread_join(g_bailian.player_thread, NULL);
+  pthread_join(g_bailian.ws_thread, NULL);
+  bailian_recorder_destroy(g_bailian.recorder);
+  bailian_player_destroy(g_bailian.player);
+  g_bailian.recorder = NULL;
+  g_bailian.player = NULL;
+  if (g_bailian.audio_buf != NULL)
+    {
+      free(g_bailian.audio_buf);
+      g_bailian.audio_buf = NULL;
+    }
+  pthread_mutex_destroy(&g_bailian.audio_mutex);
+}
+
+int main(int argc, FAR char *argv[])
+{
+  (void)argc;
+  (void)argv;
+
+  /* Ensure storage directory exists before any test */
+  mkdir("/data/bailian", 0755);
+  sync();  /* Ensure directory is persisted to filesystem */
+
+  if (argc > 1 && strcmp(argv[1], "hal_test") == 0)
+    {
+      printf("=== Bailian Official HAL Test ===\n");
+      /* Do NOT erase storage before test - SDK expects to read previous run's data */
+      int32_t ret = qwen_sdk_test();
+      printf("=== HAL Test Result: %d ===\n", ret);
+      return ret;
+    }
+
+  if (argc > 1 && strcmp(argv[1], "test") == 0)
+    {
+      printf("=== Bailian HAL Test ===\n");
+
+      printf("[MEM] util_malloc(100)... ");
+      void *p = util_malloc(100);
+      if (p != NULL)
+        {
+          printf("OK (ptr=%p)\n", p);
+          util_free(p);
+        }
+      else
+        {
+          printf("FAIL\n");
+        }
+
+      printf("[TIME] util_now_ms()... ");
+      int64_t t1 = util_now_ms();
+      usleep(10000);
+      int64_t t2 = util_now_ms();
+      if (t2 > t1)
+        {
+          printf("OK (delta=%lld ms)\n", (long long)(t2 - t1));
+        }
+      else
+        {
+          printf("FAIL (t1=%lld, t2=%lld)\n", (long long)t1, (long long)t2);
+        }
+
+      printf("[RANDOM] util_random_init + util_random()... ");
+      util_random_init(12345);
+      uint32_t r1 = util_random();
+      uint32_t r2 = util_random();
+      if (r1 != r2)
+        {
+          printf("OK (r1=%u, r2=%u)\n", r1, r2);
+        }
+      else
+        {
+          printf("WARN (same values)\n");
+        }
+
+      printf("[MUTEX] create/lock/unlock/delete... ");
+      util_mutex_t *mtx = util_mutex_create();
+      if (mtx != NULL)
+        {
+          int ret = util_mutex_lock(mtx, 100);
+          if (ret == UTIL_SUCCESS)
+            {
+              util_mutex_unlock(mtx);
+              util_mutex_delete(mtx);
+              printf("OK\n");
+            }
+          else
+            {
+              printf("FAIL (lock ret=%d)\n", ret);
+            }
+        }
+      else
+        {
+          printf("FAIL (create)\n");
+        }
+
+      printf("[STORAGE] erase/storage/load... ");
+      util_storage_erase();
+      uint8_t wdata[16] = "BAILIAN_TEST";
+      uint8_t rdata[16] = {0};
+      int ret = util_storage_storage(wdata, sizeof(wdata));
+      if (ret == UTIL_SUCCESS)
+        {
+          ret = util_storage_load(rdata, sizeof(rdata));
+          if (ret == UTIL_SUCCESS && memcmp(wdata, rdata, sizeof(wdata)) == 0)
+            {
+              printf("OK\n");
+            }
+          else
+            {
+              printf("FAIL (load ret=%d)\n", ret);
+            }
+        }
+      else
+        {
+          printf("FAIL (storage ret=%d)\n", ret);
+        }
+
+      printf("=== HAL Test Complete ===\n");
+      return 0;
+    }
+
+  if (argc > 1 && strcmp(argv[1], "test_net") == 0)
+    {
+      printf("=== Bailian Network Test ===\n");
+
+      printf("[HTTP] Testing HTTP POST to httpbin.org... ");
+      char response[1024];
+      int ret = bailian_http_post("http://httpbin.org/post",
+                                  "application/json",
+                                  "{\"test\":\"bailian\"}",
+                                  response, sizeof(response), 10000);
+      if (ret > 0)
+        {
+          printf("OK (%d bytes)\n", ret);
+        }
+      else
+        {
+          printf("FAIL (ret=%d)\n", ret);
+        }
+
+      printf("=== Network Test Complete ===\n");
+      return 0;
+    }
+
+  if (argc > 1 && strcmp(argv[1], "test_audio") == 0)
+    {
+      printf("=== Bailian Audio Test ===\n");
+
+      printf("[PLAYER] Testing WAV playback...\n");
+      const char *test_wav = "/data/data/test.wav";
+      struct bailian_player *player = bailian_player_create_from_file(test_wav);
+      if (player != NULL)
+        {
+          printf("[PLAYER] File opened, starting playback...\n");
+          if (bailian_player_start(player) == 0)
+            {
+              printf("[PLAYER] Playing... (waiting for completion)\n");
+              while (!bailian_player_is_stopped(player))
+                {
+                  usleep(100000);
+                }
+              printf("[PLAYER] Playback finished\n");
+            }
+          else
+            {
+              printf("[PLAYER] Failed to start\n");
+            }
+
+          bailian_player_destroy(player);
+        }
+      else
+        {
+          printf("[PLAYER] Failed to open %s\n", test_wav);
+        }
+
+      printf("[RECORDER] Testing nxrecorder...\n");
+      struct bailian_recorder *rec = bailian_recorder_create(
+          CONFIG_AI_BAILIAN_RECORDER_DEV, 16000, 1, 16);
+      if (rec != NULL)
+        {
+          printf("[RECORDER] Created OK\n");
+          bailian_recorder_destroy(rec);
+        }
+      else
+        {
+          printf("[RECORDER] Create failed (nxrecorder not available)\n");
+        }
+
+      printf("=== Audio Test Complete ===\n");
+      return 0;
+    }
+
+  if (argc > 1 && strcmp(argv[1], "help") == 0)
+    {
+      printf("Usage: bailian [command]\n");
+      printf("Commands:\n");
+      printf("  test        - Test HAL layer (mem, time, random, mutex, storage)\n");
+      printf("  test_net    - Test network layer (HTTP)\n");
+      printf("  test_audio  - Test audio layer (recorder, player)\n");
+      printf("  help        - Show this help\n");
+      printf("  (no args)   - Run full application\n");
+      return 0;
+    }
+
+  /* 1. Initialize SDK first (per official doc) */
+  if (c_mmi_sdk_init() != 0)
+    {
+      printf("bailian sdk init failed\n");
+      return -1;
+    }
+
+  /* 2. Register event callback first (required by SDK) */
+  c_mmi_register_event_callback(bailian_event_cb);
+
+  /* 3. Initialize MMI for pay-as-you-go mode */
+  if (c_mmi_init(CONFIG_AI_BAILIAN_WORKSPACE_ID,
+                 CONFIG_AI_BAILIAN_APP_ID,
+                 CONFIG_AI_BAILIAN_API_KEY) != 0)
+    {
+      printf("bailian mmi init failed\n");
+      return -1;
+    }
+
+  /* Pre-resolve WSS host DNS in main thread.
+   * getaddrinfo blocks in child threads on NuttX,
+   * so we cache the result here for the WS thread.
+   */
+
+  bailian_ws_dns_prefetch("dashscope.aliyuncs.com", 443);
+
+  if (bailian_init_app() != 0)
+    {
+      printf("bailian audio init failed\n");
+      return -1;
+    }
+
+  printf("bailian ready: press 't' to talk, 's' to stop, 'q' to quit\n");
+  for (;;)
+    {
+      int ch = getchar();
+      if (ch == 't')
+        {
+          /* Reset our audio buffer for new session */
+          pthread_mutex_lock(&g_bailian.audio_mutex);
+          g_bailian.audio_write_pos = 0;
+          g_bailian.audio_read_pos = 0;
+          g_bailian.audio_done = false;
+          pthread_mutex_unlock(&g_bailian.audio_mutex);
+          /* Open streaming capture — use file if available, else device */
+          int file_test = open("/data/speech_24k.pcm", O_RDONLY);
+          if (file_test >= 0)
+            {
+              close(file_test);
+              printf("[bailian] Using PCM file injection mode\n");
+              bailian_recorder_open(g_bailian.recorder,
+                                   "/data/speech_24k.pcm",
+                                   24000, 1, 16);
+            }
+          else
+            {
+              bailian_recorder_open(g_bailian.recorder,
+                                   CONFIG_AI_BAILIAN_RECORDER_DEV,
+                                   24000, 1, 16);
+            }
+          g_bailian.recording = true;
+          g_bailian.speech_started = false;
+          g_bailian.stop_requested = false;
+          g_bailian.record_start_ms = bailian_now_ms();
+          c_mmi_speech_start();
+          printf("[bailian] recording started at %lld ms\n",
+                 (long long)g_bailian.record_start_ms);
+        }
+
+      else if (ch == 's')
+        {
+          /* Stop recording, let ws_loop drain ring buffer then speech_end */
+          g_bailian.recording = false;
+          g_bailian.stop_requested = true;
+          printf("[bailian] stop requested, ws_loop will drain audio and call speech_end\n");
+        }
+      else if (ch == 'q')
+        {
+          break;
+        }
+      else
+        {
+          usleep(10000);
+        }
+    }
+
+  bailian_deinit_app();
+  c_mmi_deinit();
+  return 0;
+}

--- a/bailian/hal/hal_mem.c
+++ b/bailian/hal/hal_mem.c
@@ -1,0 +1,44 @@
+#include <assert.h>
+#include <stdlib.h>
+
+#include "c_utils/hal_util_mem.h"
+
+/* Compatibility wrapper for newlib's __assert_func used by SDK */
+
+void __assert_func(const char *file, int line,
+                   const char *func, const char *expr)
+{
+  (void)func;
+  __assert(file, line, expr);
+}
+
+void *util_malloc(int32_t size)
+{
+  if (size <= 0)
+    {
+      return NULL;
+    }
+
+  return malloc((size_t)size);
+}
+
+void util_free(void *ptr)
+{
+  if (ptr == NULL)
+    {
+      return;
+    }
+
+  free(ptr);
+}
+
+void *util_realloc(void *ptr, int32_t size)
+{
+  if (size <= 0)
+    {
+      free(ptr);
+      return NULL;
+    }
+
+  return realloc(ptr, (size_t)size);
+}

--- a/bailian/hal/hal_mutex.c
+++ b/bailian/hal/hal_mutex.c
@@ -1,0 +1,127 @@
+#include <errno.h>
+#include <pthread.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "c_utils/hal_util_mutex.h"
+#include "c_utils/c_utils.h"
+
+static int mutex_trylock_with_timeout(pthread_mutex_t *mutex, int32_t timeout)
+{
+  int32_t elapsed = 0;
+
+  while (elapsed < timeout)
+    {
+      int ret = pthread_mutex_trylock(mutex);
+      if (ret == 0)
+        {
+          return UTIL_SUCCESS;
+        }
+
+      if (ret != EBUSY)
+        {
+          return UTIL_ERR_FAIL;
+        }
+
+      usleep(1000);
+      elapsed += 1;
+    }
+
+  return UTIL_ERR_TIMEOUT;
+}
+
+util_mutex_t *util_mutex_create(void)
+{
+  util_mutex_t *mutex;
+  pthread_mutex_t *handle;
+
+  mutex = (util_mutex_t *)malloc(sizeof(util_mutex_t));
+  if (mutex == NULL)
+    {
+      return NULL;
+    }
+
+  handle = (pthread_mutex_t *)malloc(sizeof(pthread_mutex_t));
+  if (handle == NULL)
+    {
+      free(mutex);
+      return NULL;
+    }
+
+  if (pthread_mutex_init(handle, NULL) != 0)
+    {
+      free(handle);
+      free(mutex);
+      return NULL;
+    }
+
+  mutex->mutex_handle = handle;
+  return mutex;
+}
+
+void util_mutex_delete(util_mutex_t *mutex)
+{
+  pthread_mutex_t *handle;
+
+  if (mutex == NULL)
+    {
+      return;
+    }
+
+  handle = (pthread_mutex_t *)mutex->mutex_handle;
+  if (handle != NULL)
+    {
+      pthread_mutex_destroy(handle);
+      free(handle);
+    }
+
+  free(mutex);
+}
+
+int32_t util_mutex_lock(util_mutex_t *mutex, int32_t timeout)
+{
+  pthread_mutex_t *handle;
+  int ret;
+
+  if (mutex == NULL || mutex->mutex_handle == NULL)
+    {
+      return UTIL_ERR_INVALID_PARAM;
+    }
+
+  handle = (pthread_mutex_t *)mutex->mutex_handle;
+
+  if (timeout == MUTEX_WAIT_FOREVER)
+    {
+      ret = pthread_mutex_lock(handle);
+      return ret == 0 ? UTIL_SUCCESS : UTIL_ERR_FAIL;
+    }
+
+  if (timeout <= 0)
+    {
+      ret = pthread_mutex_trylock(handle);
+      if (ret == 0)
+        {
+          return UTIL_SUCCESS;
+        }
+      return ret == EBUSY ? UTIL_ERR_TIMEOUT : UTIL_ERR_FAIL;
+    }
+
+  return mutex_trylock_with_timeout(handle, timeout);
+}
+
+int32_t util_mutex_unlock(util_mutex_t *mutex)
+{
+  pthread_mutex_t *handle;
+  int ret;
+
+  if (mutex == NULL || mutex->mutex_handle == NULL)
+    {
+      return UTIL_ERR_INVALID_PARAM;
+    }
+
+  handle = (pthread_mutex_t *)mutex->mutex_handle;
+  ret = pthread_mutex_unlock(handle);
+  return ret == 0 ? UTIL_SUCCESS : UTIL_ERR_FAIL;
+}

--- a/bailian/hal/hal_random.c
+++ b/bailian/hal/hal_random.c
@@ -1,0 +1,42 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "c_utils/hal_util_random.h"
+
+static uint32_t g_prng_seed = 1;
+static uint8_t g_prng_initialized = 0;
+
+int32_t util_random_init(uint32_t seed)
+{
+  g_prng_seed = seed;
+  g_prng_initialized = 1;
+  srand(seed);
+  return 0;
+}
+
+uint32_t util_random(void)
+{
+  uint32_t value = 0;
+  int fd;
+  ssize_t ret;
+  /* Try hardware random first */
+  fd = open("/dev/urandom", O_RDONLY);
+  if (fd >= 0)
+    {
+      ret = read(fd, &value, sizeof(value));
+      close(fd);
+      if (ret == (ssize_t)sizeof(value))
+        {
+          return value;
+        }
+    }
+  /* Fallback to PRNG */
+  if (!g_prng_initialized)
+    {
+      util_random_init(1);
+    }
+  return (uint32_t)rand();
+}

--- a/bailian/hal/hal_storage.c
+++ b/bailian/hal/hal_storage.c
@@ -1,0 +1,117 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "c_utils/hal_util_storage.h"
+
+#define BAILIAN_STORAGE_DIR  "/data/bailian"
+#define BAILIAN_STORAGE_FILE "/data/bailian/storage.bin"
+
+static int ensure_storage_dir(void)
+{
+  struct stat st;
+  if (stat(BAILIAN_STORAGE_DIR, &st) == 0)
+    {
+      return 0;  /* Directory exists */
+    }
+  if (mkdir(BAILIAN_STORAGE_DIR, 0755) == 0)
+    {
+      sync();  /* Ensure directory is persisted */
+      return 0;
+    }
+  if (errno == EEXIST)
+    {
+      return 0;
+    }
+  return -errno;
+}
+
+int32_t util_storage_erase(void)
+{
+  int ret;
+  ret = ensure_storage_dir();
+  if (ret < 0)
+    {
+      return UTIL_ERR_IO;
+    }
+  ret = unlink(BAILIAN_STORAGE_FILE);
+  if (ret == 0 || errno == ENOENT)
+    {
+      sync();
+      return UTIL_SUCCESS;
+    }
+  return UTIL_ERR_IO;
+}
+
+int32_t util_storage_storage(uint8_t *data, uint32_t size)
+{
+  int fd;
+  ssize_t written = 0;
+  ssize_t ret;
+  if (data == NULL || size == 0)
+    {
+      return UTIL_ERR_INVALID_PARAM;
+    }
+  ret = ensure_storage_dir();
+  if (ret < 0)
+    {
+      return UTIL_ERR_IO;
+    }
+  fd = open(BAILIAN_STORAGE_FILE, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+  if (fd < 0)
+    {
+      return UTIL_ERR_IO;
+    }
+  while ((uint32_t)written < size)
+    {
+      ret = write(fd, data + written, size - (uint32_t)written);
+      if (ret < 0)
+        {
+          close(fd);
+          return UTIL_ERR_IO;
+        }
+      written += ret;
+    }
+  fsync(fd);
+  close(fd);
+  return UTIL_SUCCESS;
+}
+
+int32_t util_storage_load(uint8_t *data, uint32_t size)
+{
+  int fd;
+  ssize_t total = 0;
+  ssize_t ret;
+  if (data == NULL || size == 0)
+    {
+      return UTIL_ERR_INVALID_PARAM;
+    }
+  fd = open(BAILIAN_STORAGE_FILE, O_RDONLY);
+  if (fd < 0)
+    {
+      if (errno == ENOENT)
+        {
+          return UTIL_ERR_NOT_FOUND;
+        }
+      return UTIL_ERR_IO;
+    }
+  while ((uint32_t)total < size)
+    {
+      ret = read(fd, data + total, size - (uint32_t)total);
+      if (ret < 0)
+        {
+          close(fd);
+          return UTIL_ERR_IO;
+        }
+      if (ret == 0)
+        {
+          close(fd);
+          return UTIL_ERR_FAIL;
+        }
+      total += ret;
+    }
+  close(fd);
+  return UTIL_SUCCESS;
+}

--- a/bailian/hal/hal_time.c
+++ b/bailian/hal/hal_time.c
@@ -1,0 +1,50 @@
+#include <errno.h>
+#include <stdint.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "c_utils/hal_util_time.h"
+
+int64_t util_now_ms(void)
+{
+  struct timespec ts;
+
+  if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0)
+    {
+      return 0;
+    }
+
+  return (int64_t)ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+}
+
+void util_msleep(uint32_t ms)
+{
+  if (ms == 0)
+    {
+      return;
+    }
+
+  usleep((useconds_t)ms * 1000);
+}
+
+int64_t util_get_timestamp(void)
+{
+  struct timespec ts;
+
+  if (clock_gettime(CLOCK_REALTIME, &ts) != 0)
+    {
+      return 0;
+    }
+
+  return (int64_t)ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+}
+
+int64_t util_get_timestamp_ms(void)
+{
+  return util_get_timestamp();
+}
+
+uint8_t util_timestamp_inited(void)
+{
+  return 1;
+}

--- a/bailian/net/http_client.c
+++ b/bailian/net/http_client.c
@@ -1,0 +1,739 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <netdb.h>
+#include <poll.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+#include <nuttx/config.h>
+
+#include "c_utils/c_utils.h"
+
+#ifdef CONFIG_CRYPTO_MBEDTLS
+#include <mbedtls/ctr_drbg.h>
+#include <mbedtls/entropy.h>
+#include <mbedtls/error.h>
+#include <mbedtls/net_sockets.h>
+#include <mbedtls/ssl.h>
+#endif
+#include "cJSON.h"
+
+#define HTTP_DEFAULT_PORT 80
+#define HTTPS_DEFAULT_PORT 443
+
+struct http_url_s
+{
+  char scheme[6];
+  char host[128];
+  char path[256];
+  uint16_t port;
+  bool tls;
+};
+
+struct http_tls_s
+{
+#ifdef CONFIG_CRYPTO_MBEDTLS
+  mbedtls_net_context net;
+  mbedtls_ssl_context ssl;
+  mbedtls_ssl_config conf;
+  mbedtls_ctr_drbg_context ctr_drbg;
+  mbedtls_entropy_context entropy;
+#endif
+  bool inited;
+};
+
+static int parse_url(const char *url, struct http_url_s *out)
+{
+  const char *host_start;
+  const char *path_start;
+  const char *port_start;
+  size_t host_len;
+  size_t path_len;
+
+  if (url == NULL || out == NULL)
+    {
+      return -EINVAL;
+    }
+
+  memset(out, 0, sizeof(*out));
+
+  if (strncmp(url, "http://", 7) == 0)
+    {
+      strcpy(out->scheme, "http");
+      out->port = HTTP_DEFAULT_PORT;
+      out->tls = false;
+      host_start = url + 7;
+    }
+  else if (strncmp(url, "https://", 8) == 0)
+    {
+      strcpy(out->scheme, "https");
+      out->port = HTTPS_DEFAULT_PORT;
+      out->tls = true;
+      host_start = url + 8;
+    }
+  else
+    {
+      return -EINVAL;
+    }
+
+  path_start = strchr(host_start, '/');
+  if (path_start == NULL)
+    {
+      path_start = host_start + strlen(host_start);
+    }
+
+  port_start = memchr(host_start, ':', (size_t)(path_start - host_start));
+  if (port_start != NULL)
+    {
+      host_len = (size_t)(port_start - host_start);
+      out->port = (uint16_t)strtoul(port_start + 1, NULL, 10);
+    }
+  else
+    {
+      host_len = (size_t)(path_start - host_start);
+    }
+
+  if (host_len == 0 || host_len >= sizeof(out->host))
+    {
+      return -EINVAL;
+    }
+
+  memcpy(out->host, host_start, host_len);
+  out->host[host_len] = '\0';
+
+  if (*path_start == '\0')
+    {
+      strcpy(out->path, "/");
+    }
+  else
+    {
+      path_len = strlen(path_start);
+      if (path_len >= sizeof(out->path))
+        {
+          return -EINVAL;
+        }
+      memcpy(out->path, path_start, path_len + 1);
+    }
+
+  return 0;
+}
+
+static int tcp_connect(const char *host, uint16_t port, int timeout_ms)
+{
+  struct addrinfo hints;
+  struct addrinfo *res = NULL;
+  struct addrinfo *it;
+  char port_str[8];
+  int fd = -1;
+  int ret;
+
+  snprintf(port_str, sizeof(port_str), "%u", port);
+  memset(&hints, 0, sizeof(hints));
+  hints.ai_family = AF_UNSPEC;
+  hints.ai_socktype = SOCK_STREAM;
+
+  ret = getaddrinfo(host, port_str, &hints, &res);
+  if (ret != 0)
+    {
+      return -EHOSTUNREACH;
+    }
+
+  for (it = res; it != NULL; it = it->ai_next)
+    {
+      struct timeval tv;
+
+      fd = socket(it->ai_family, it->ai_socktype, it->ai_protocol);
+      if (fd < 0)
+        {
+          continue;
+        }
+
+      tv.tv_sec = timeout_ms / 1000;
+      tv.tv_usec = (timeout_ms % 1000) * 1000;
+      setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+      setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+
+      ret = connect(fd, it->ai_addr, it->ai_addrlen);
+      if (ret == 0)
+        {
+          break;
+        }
+
+      close(fd);
+      fd = -1;
+    }
+
+  freeaddrinfo(res);
+  return fd;
+}
+
+static ssize_t socket_write(int fd, const uint8_t *data, size_t len)
+{
+  size_t sent = 0;
+
+  while (sent < len)
+    {
+      ssize_t ret = send(fd, data + sent, len - sent, 0);
+      if (ret < 0)
+        {
+          if (errno == EINTR)
+            {
+              continue;
+            }
+          return -errno;
+        }
+      sent += (size_t)ret;
+    }
+
+  return (ssize_t)sent;
+}
+
+static ssize_t socket_read(int fd, uint8_t *data, size_t len)
+{
+  ssize_t ret = recv(fd, data, len, 0);
+  if (ret < 0 && errno == EINTR)
+    {
+      return 0;
+    }
+  return ret;
+}
+
+#ifdef CONFIG_CRYPTO_MBEDTLS
+
+/* Custom recv with poll() timeout for NuttX FDCHECK compatibility */
+
+static int http_net_recv(void *ctx, unsigned char *buf, size_t len)
+{
+  mbedtls_net_context *net_ctx = (mbedtls_net_context *)ctx;
+  struct pollfd pfd;
+  int ret;
+
+  pfd.fd = net_ctx->fd;
+  pfd.events = POLLIN;
+  pfd.revents = 0;
+
+  ret = poll(&pfd, 1, 10000);
+
+  if (ret == 0)
+    {
+      return MBEDTLS_ERR_SSL_TIMEOUT;
+    }
+
+  if (ret < 0)
+    {
+      return MBEDTLS_ERR_NET_RECV_FAILED;
+    }
+
+  if (pfd.revents & (POLLERR | POLLHUP))
+    {
+      return MBEDTLS_ERR_NET_CONN_RESET;
+    }
+
+  ret = (int)read(net_ctx->fd, buf, len);
+
+  if (ret < 0)
+    {
+      if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR)
+        {
+          return MBEDTLS_ERR_SSL_WANT_READ;
+        }
+
+      if (errno == EPIPE || errno == ECONNRESET)
+        {
+          return MBEDTLS_ERR_NET_CONN_RESET;
+        }
+
+      return MBEDTLS_ERR_NET_RECV_FAILED;
+    }
+
+  return ret;
+}
+
+/* IPv4-only TCP connect to avoid FDCHECK + select() issues */
+
+static int http_tcp_connect_ipv4(const char *host, uint16_t port,
+                                 int timeout_ms)
+{
+  struct addrinfo hints;
+  struct addrinfo *res = NULL;
+  struct addrinfo *it;
+  char port_str[8];
+  struct timeval tv;
+  int fd = -1;
+  int ret;
+
+  snprintf(port_str, sizeof(port_str), "%u", port);
+  memset(&hints, 0, sizeof(hints));
+  hints.ai_family = AF_INET;
+  hints.ai_socktype = SOCK_STREAM;
+
+  ret = getaddrinfo(host, port_str, &hints, &res);
+  if (ret != 0)
+    {
+      return -EHOSTUNREACH;
+    }
+
+  for (it = res; it != NULL; it = it->ai_next)
+    {
+      fd = socket(it->ai_family, it->ai_socktype, it->ai_protocol);
+      if (fd < 0)
+        {
+          continue;
+        }
+
+      tv.tv_sec = timeout_ms / 1000;
+      tv.tv_usec = (timeout_ms % 1000) * 1000;
+      setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+      setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+
+      ret = connect(fd, it->ai_addr, it->ai_addrlen);
+      if (ret == 0)
+        {
+          break;
+        }
+
+      close(fd);
+      fd = -1;
+    }
+
+  freeaddrinfo(res);
+  return fd;
+}
+
+static int tls_connect(struct http_tls_s *tls, const char *host,
+                       uint16_t port, int timeout_ms)
+{
+  int ret;
+  int fd;
+
+  if (tls == NULL)
+    {
+      return -EINVAL;
+    }
+
+  mbedtls_net_init(&tls->net);
+  mbedtls_ssl_init(&tls->ssl);
+  mbedtls_ssl_config_init(&tls->conf);
+  mbedtls_ctr_drbg_init(&tls->ctr_drbg);
+  mbedtls_entropy_init(&tls->entropy);
+
+  ret = mbedtls_ctr_drbg_seed(&tls->ctr_drbg, mbedtls_entropy_func,
+                              &tls->entropy, (const unsigned char *)"bailian",
+                              strlen("bailian"));
+  if (ret != 0)
+    {
+      return -EIO;
+    }
+
+  /* Use custom IPv4-only connect instead of mbedtls_net_connect
+   * to avoid internal select()/FD_SET issues with FDCHECK.
+   */
+
+  fd = http_tcp_connect_ipv4(host, port, timeout_ms);
+  if (fd < 0)
+    {
+      return -EHOSTUNREACH;
+    }
+
+  tls->net.fd = fd;
+
+  ret = mbedtls_ssl_config_defaults(&tls->conf, MBEDTLS_SSL_IS_CLIENT,
+                                    MBEDTLS_SSL_TRANSPORT_STREAM,
+                                    MBEDTLS_SSL_PRESET_DEFAULT);
+  if (ret != 0)
+    {
+      return -EIO;
+    }
+
+  mbedtls_ssl_conf_authmode(&tls->conf, MBEDTLS_SSL_VERIFY_NONE);
+  mbedtls_ssl_conf_rng(&tls->conf, mbedtls_ctr_drbg_random, &tls->ctr_drbg);
+  if (timeout_ms > 0)
+    {
+      mbedtls_ssl_conf_read_timeout(&tls->conf, timeout_ms);
+    }
+
+  ret = mbedtls_ssl_setup(&tls->ssl, &tls->conf);
+  if (ret != 0)
+    {
+      return -EIO;
+    }
+
+  ret = mbedtls_ssl_set_hostname(&tls->ssl, host);
+  if (ret != 0)
+    {
+      return -EIO;
+    }
+
+  /* Use custom recv with poll() to avoid select()/FD_SET overflow
+   * caused by FDCHECK-encoded fd values exceeding FD_SETSIZE.
+   */
+
+  mbedtls_ssl_set_bio(&tls->ssl, &tls->net, mbedtls_net_send,
+                      http_net_recv, NULL);
+
+  do
+    {
+      ret = mbedtls_ssl_handshake(&tls->ssl);
+    }
+  while (ret == MBEDTLS_ERR_SSL_WANT_READ ||
+         ret == MBEDTLS_ERR_SSL_WANT_WRITE);
+
+  if (ret != 0)
+    {
+      return -EIO;
+    }
+
+  tls->inited = true;
+  return 0;
+}
+
+static void tls_close(struct http_tls_s *tls)
+{
+  if (tls == NULL || !tls->inited)
+    {
+      return;
+    }
+
+  mbedtls_ssl_close_notify(&tls->ssl);
+  mbedtls_net_free(&tls->net);
+  mbedtls_ssl_free(&tls->ssl);
+  mbedtls_ssl_config_free(&tls->conf);
+  mbedtls_ctr_drbg_free(&tls->ctr_drbg);
+  mbedtls_entropy_free(&tls->entropy);
+  tls->inited = false;
+}
+
+static ssize_t tls_write(struct http_tls_s *tls, const uint8_t *data,
+                         size_t len)
+{
+  size_t sent = 0;
+
+  while (sent < len)
+    {
+      int ret = mbedtls_ssl_write(&tls->ssl, data + sent, len - sent);
+      if (ret < 0)
+        {
+          if (ret == MBEDTLS_ERR_SSL_WANT_READ ||
+              ret == MBEDTLS_ERR_SSL_WANT_WRITE)
+            {
+              continue;
+            }
+          return -EIO;
+        }
+      sent += (size_t)ret;
+    }
+
+  return (ssize_t)sent;
+}
+
+static ssize_t tls_read(struct http_tls_s *tls, uint8_t *data, size_t len)
+{
+  int ret = mbedtls_ssl_read(&tls->ssl, data, len);
+  if (ret == MBEDTLS_ERR_SSL_WANT_READ || ret == MBEDTLS_ERR_SSL_WANT_WRITE)
+    {
+      return 0;
+    }
+  if (ret == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY)
+    {
+      return 0;
+    }
+  if (ret < 0)
+    {
+      return -EIO;
+    }
+  return ret;
+}
+#endif
+
+static const char *find_header_case(const char *haystack, const char *needle)
+{
+  size_t needle_len;
+  const char *p;
+
+  if (haystack == NULL || needle == NULL)
+    {
+      return NULL;
+    }
+
+  needle_len = strlen(needle);
+  for (p = haystack; *p != '\0'; p++)
+    {
+      if (strncasecmp(p, needle, needle_len) == 0)
+        {
+          return p;
+        }
+    }
+
+  return NULL;
+}
+
+static int http_read_response(int fd, struct http_tls_s *tls, bool use_tls,
+                              char *response, size_t response_len)
+{
+  uint8_t buffer[512];
+  char *header_end = NULL;
+  size_t header_len = 0;
+  size_t body_len = 0;
+  size_t content_len = 0;
+  bool has_content_len = false;
+
+  while (true)
+    {
+      ssize_t ret = use_tls
+#ifdef CONFIG_CRYPTO_MBEDTLS
+                        ? tls_read(tls, buffer, sizeof(buffer))
+#else
+                        ? -ENOTSUP
+#endif
+                        : socket_read(fd, buffer, sizeof(buffer));
+      if (ret < 0)
+        {
+          return (int)ret;
+        }
+      if (ret == 0)
+        {
+          break;
+        }
+
+      if (header_end == NULL)
+        {
+          size_t copy_len = (size_t)ret;
+          if (header_len + copy_len >= response_len)
+            {
+              return -ENOSPC;
+            }
+
+          memcpy(response + header_len, buffer, copy_len);
+          header_len += copy_len;
+          response[header_len] = '\0';
+          header_end = strstr(response, "\r\n\r\n");
+          if (header_end != NULL)
+            {
+              const char *len_str = find_header_case(response, "Content-Length:");
+              if (len_str != NULL)
+                {
+                  len_str += strlen("Content-Length:");
+                  while (*len_str == ' ') len_str++;
+                  content_len = (size_t)strtoul(len_str, NULL, 10);
+                  has_content_len = true;
+                }
+
+              body_len = header_len - (size_t)(header_end - response) - 4;
+              memmove(response, header_end + 4, body_len);
+              header_len = 0;
+              response[body_len] = '\0';
+
+              if (has_content_len && body_len >= content_len)
+                {
+                  return (int)body_len;
+                }
+            }
+        }
+      else
+        {
+          size_t copy_len = (size_t)ret;
+          if (body_len + copy_len >= response_len)
+            {
+              return -ENOSPC;
+            }
+          memcpy(response + body_len, buffer, copy_len);
+          body_len += copy_len;
+          response[body_len] = '\0';
+          if (has_content_len && body_len >= content_len)
+            {
+              return (int)body_len;
+            }
+        }
+    }
+
+  return (int)body_len;
+}
+
+int bailian_http_post(const char *url, const char *content_type,
+                      const char *payload, char *response,
+                      size_t response_len, int timeout_ms)
+{
+  struct http_url_s parsed;
+  char request[512];
+  int fd = -1;
+  int ret;
+  size_t payload_len = payload != NULL ? strlen(payload) : 0;
+  ssize_t sent;
+  struct http_tls_s tls;
+
+  if (parse_url(url, &parsed) != 0)
+    {
+      return -EINVAL;
+    }
+
+  memset(&tls, 0, sizeof(tls));
+
+  if (parsed.tls)
+    {
+#ifdef CONFIG_CRYPTO_MBEDTLS
+      ret = tls_connect(&tls, parsed.host, parsed.port, timeout_ms);
+      if (ret < 0)
+        {
+          return ret;
+        }
+#else
+      return -ENOTSUP;
+#endif
+    }
+  else
+    {
+      fd = tcp_connect(parsed.host, parsed.port, timeout_ms);
+      if (fd < 0)
+        {
+          return fd;
+        }
+    }
+
+  snprintf(request, sizeof(request),
+           "POST %s HTTP/1.1\r\n"
+           "Host: %s\r\n"
+           "Connection: close\r\n"
+           "Content-Type: %s\r\n"
+           "Content-Length: %u\r\n"
+           "\r\n",
+           parsed.path, parsed.host,
+           content_type != NULL ? content_type : "application/json",
+           (unsigned int)payload_len);
+
+  if (parsed.tls)
+    {
+#ifdef CONFIG_CRYPTO_MBEDTLS
+      sent = tls_write(&tls, (const uint8_t *)request, strlen(request));
+#else
+      sent = -ENOTSUP;
+#endif
+    }
+  else
+    {
+      sent = socket_write(fd, (const uint8_t *)request, strlen(request));
+    }
+
+  if (sent < 0)
+    {
+      ret = (int)sent;
+      goto out;
+    }
+
+  if (payload_len > 0)
+    {
+      if (parsed.tls)
+        {
+#ifdef CONFIG_CRYPTO_MBEDTLS
+          sent = tls_write(&tls, (const uint8_t *)payload, payload_len);
+#else
+          sent = -ENOTSUP;
+#endif
+        }
+      else
+        {
+          sent = socket_write(fd, (const uint8_t *)payload, payload_len);
+        }
+
+      if (sent < 0)
+        {
+          ret = (int)sent;
+          goto out;
+        }
+    }
+
+  ret = http_read_response(fd, &tls, parsed.tls, response, response_len);
+
+out:
+  if (parsed.tls)
+    {
+#ifdef CONFIG_CRYPTO_MBEDTLS
+      tls_close(&tls);
+#endif
+    }
+  else if (fd >= 0)
+    {
+      close(fd);
+    }
+
+  return ret;
+}
+
+/* Extract 'data' field from JSON response for SDK parsing */
+static int extract_json_data(const char *json_str, char *data_out, size_t data_len)
+{
+  cJSON *root = NULL;
+  cJSON *data = NULL;
+  char *data_str = NULL;
+  int ret = -1;
+
+  root = cJSON_Parse(json_str);
+  if (root == NULL)
+    {
+      return -1;
+    }
+
+  data = cJSON_GetObjectItem(root, "data");
+  if (data == NULL)
+    {
+      cJSON_Delete(root);
+      return -1;
+    }
+
+  data_str = cJSON_PrintUnformatted(data);
+  if (data_str != NULL)
+    {
+      size_t len = strlen(data_str);
+      if (len < data_len)
+        {
+          memcpy(data_out, data_str, len + 1);
+          ret = (int)len;
+        }
+      cJSON_free(data_str);
+    }
+
+  cJSON_Delete(root);
+  return ret;
+}
+
+int bailian_http_register(const char *url, const char *req,
+                          char *rsp, size_t rsp_len)
+{
+  char raw_rsp[2048];
+  int ret;
+
+  ret = bailian_http_post(url, "application/json", req, raw_rsp,
+                          sizeof(raw_rsp), 10000);
+  if (ret <= 0)
+    {
+      return ret;
+    }
+
+  /* Extract 'data' field from JSON response per official doc */
+  ret = extract_json_data(raw_rsp, rsp, rsp_len);
+  return ret;
+}
+
+int bailian_http_login(const char *url, const char *req,
+                       char *rsp, size_t rsp_len)
+{
+  char raw_rsp[2048];
+  int ret;
+
+  ret = bailian_http_post(url, "application/json", req, raw_rsp,
+                          sizeof(raw_rsp), 10000);
+  if (ret <= 0)
+    {
+      return ret;
+    }
+
+  /* Extract 'data' field from JSON response per official doc */
+  ret = extract_json_data(raw_rsp, rsp, rsp_len);
+  return ret;
+}

--- a/bailian/net/websocket.c
+++ b/bailian/net/websocket.c
@@ -1,0 +1,1296 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <netdb.h>
+#include <poll.h>
+#include <pthread.h>
+#include <semaphore.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/select.h>
+#include <sys/socket.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <nuttx/config.h>
+
+#ifdef CONFIG_CRYPTO_MBEDTLS
+#include <mbedtls/ctr_drbg.h>
+#ifdef CONFIG_MBEDTLS_DEBUG_C
+#include <mbedtls/debug.h>
+#endif
+#include <mbedtls/entropy.h>
+#include <mbedtls/net_sockets.h>
+#include <mbedtls/ssl.h>
+#include <mbedtls/x509_crt.h>
+
+#ifdef CONFIG_MBEDTLS_DEBUG_C
+static void my_debug(void *ctx, int level, const char *file, int line,
+                     const char *str)
+{
+  (void)ctx;
+  (void)level;
+}
+#endif
+
+/* GlobalSign Root CA - R3 (PEM format)
+ * Valid: 2009-03-18 to 2029-03-18
+ * Required by Alibaba Bailian/DashScope TLS connection
+ */
+
+static const char globalsign_root_r3_pem[] =
+  "-----BEGIN CERTIFICATE-----\r\n"
+  "MIIDXzCCAkegAwIBAgILBAAAAAABIVhTCKIwDQYJKoZIhvcNAQELBQAwTDEgMB4G\r\n"
+  "A1UECxMXR2xvYmFsU2lnbiBSb290IENBIC0gUjMxEzARBgNVBAoTCkdsb2JhbFNp\r\n"
+  "Z24xEzARBgNVBAMTCkdsb2JhbFNpZ24wHhcNMDkwMzE4MTAwMDAwWhcNMjkwMzE4\r\n"
+  "MTAwMDAwWjBMMSAwHgYDVQQLExdHbG9iYWxTaWduIFJvb3QgQ0EgLSBSMzETMBEG\r\n"
+  "A1UEChMKR2xvYmFsU2lnbjETMBEGA1UEAxMKR2xvYmFsU2lnbjCCASIwDQYJKoZI\r\n"
+  "hvcNAQEBBQADggEPADCCAQoCggEBAMwldpB5BngiFvXAg7aEyiie/QV2EcWtiHL8\r\n"
+  "RgJDx7KKnQRfJMsuS+FggkbhUqsMgUdwbN1k0ev1LKMPgj0MK66X17YUhhB5uzsT\r\n"
+  "gHeMCOFJ0mpiLx9e+pZo34knlTifBtc+ycsmWQ1z3rDI6SYOgxXG71uL0gRgykmm\r\n"
+  "KPZpO/bLyCiR5Z2KYVc3rHQU3HTgOu5yLy6c+9C7v/U9AOEGM+iCK65TpjoWc4zd\r\n"
+  "QQ4gOsC0p6Hpsk+QLjJg6VfLuQSSaGjlOCZgdbKfd/+RFO+uIEn8rUAVSNECMWEZ\r\n"
+  "XriX7613t2Saer9fwRPvm2L7DWzgVGkWqQPabumDk3F2xmmFghcCAwEAAaNCMEAw\r\n"
+  "DgYDVR0PAQH/BAQDAgEGMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFI/wS3+o\r\n"
+  "LkUkrk1Q+mOai97i3Ru8MA0GCSqGSIb3DQEBCwUAA4IBAQBLQNvAUKr+yAzv95ZU\r\n"
+  "RUm7lgAJQayzE4aGKAczymvmdLm6AC2upArT9fHxD4q/c2dKg8dEe3jgr25sbwMp\r\n"
+  "jjM5RcOO5LlXbKr8EpbsU8Yt5CRsuZRj+9xTaGdWPoO4zzUhw8lo/s7awlOqzJCK\r\n"
+  "6fBdRoyV3XpYKBovHd7NADdBj+1EbddTKJd+82cEHhXXipa0095MJ6RMG3NzdvQX\r\n"
+  "mcIfeg7jLQitChws/zyrVQ4PkX4268NXSb7hLi18YIvDQVETI53O9zJrlAGomecs\r\n"
+  "Mx86OyXShkDOOyyGeMlhLxS67ttVb9+E7gUJTb0o2HLO02JQZR7rkpeDMdmztcpH\r\n"
+  "WD9f\r\n"
+  "-----END CERTIFICATE-----\r\n";
+#endif
+
+#define WS_GUID "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+
+struct ws_url_s
+{
+  char host[128];
+  char path[256];
+  uint16_t port;
+  bool tls;
+};
+
+struct ws_tls_s
+{
+#ifdef CONFIG_CRYPTO_MBEDTLS
+  mbedtls_net_context net;
+  mbedtls_ssl_context ssl;
+  mbedtls_ssl_config conf;
+  mbedtls_ctr_drbg_context ctr_drbg;
+  mbedtls_entropy_context entropy;
+  mbedtls_x509_crt cacert;
+#endif
+  bool inited;
+};
+
+struct bailian_ws_client
+{
+  int fd;
+  bool tls;
+  struct ws_tls_s tls_ctx;
+};
+
+typedef struct
+{
+  uint32_t state[5];
+  uint64_t count;
+  uint8_t buffer[64];
+} sha1_ctx_t;
+
+static void sha1_transform(uint32_t state[5], const uint8_t buffer[64])
+{
+  uint32_t a, b, c, d, e, t;
+  uint32_t w[80];
+  int i;
+
+  for (i = 0; i < 16; i++)
+    {
+      w[i] = ((uint32_t)buffer[i * 4] << 24) |
+             ((uint32_t)buffer[i * 4 + 1] << 16) |
+             ((uint32_t)buffer[i * 4 + 2] << 8) |
+             (uint32_t)buffer[i * 4 + 3];
+    }
+
+  for (i = 16; i < 80; i++)
+    {
+      uint32_t v = w[i - 3] ^ w[i - 8] ^ w[i - 14] ^ w[i - 16];
+      w[i] = (v << 1) | (v >> 31);
+    }
+
+  a = state[0];
+  b = state[1];
+  c = state[2];
+  d = state[3];
+  e = state[4];
+
+  for (i = 0; i < 80; i++)
+    {
+      uint32_t f;
+      uint32_t k;
+
+      if (i < 20)
+        {
+          f = (b & c) | ((~b) & d);
+          k = 0x5A827999;
+        }
+      else if (i < 40)
+        {
+          f = b ^ c ^ d;
+          k = 0x6ED9EBA1;
+        }
+      else if (i < 60)
+        {
+          f = (b & c) | (b & d) | (c & d);
+          k = 0x8F1BBCDC;
+        }
+      else
+        {
+          f = b ^ c ^ d;
+          k = 0xCA62C1D6;
+        }
+
+      t = ((a << 5) | (a >> 27)) + f + e + k + w[i];
+      e = d;
+      d = c;
+      c = (b << 30) | (b >> 2);
+      b = a;
+      a = t;
+    }
+
+  state[0] += a;
+  state[1] += b;
+  state[2] += c;
+  state[3] += d;
+  state[4] += e;
+}
+
+static void sha1_init(sha1_ctx_t *ctx)
+{
+  ctx->state[0] = 0x67452301;
+  ctx->state[1] = 0xEFCDAB89;
+  ctx->state[2] = 0x98BADCFE;
+  ctx->state[3] = 0x10325476;
+  ctx->state[4] = 0xC3D2E1F0;
+  ctx->count = 0;
+}
+
+static void sha1_update(sha1_ctx_t *ctx, const uint8_t *data, size_t len)
+{
+  size_t i;
+  size_t index = (size_t)((ctx->count >> 3) & 0x3f);
+
+  ctx->count += (uint64_t)len << 3;
+
+  for (i = 0; i < len; i++)
+    {
+      ctx->buffer[index++] = data[i];
+      if (index == 64)
+        {
+          sha1_transform(ctx->state, ctx->buffer);
+          index = 0;
+        }
+    }
+}
+
+static void sha1_final(sha1_ctx_t *ctx, uint8_t digest[20])
+{
+  uint8_t pad[64];
+  uint8_t len_bytes[8];
+  size_t index;
+  size_t pad_len;
+  int i;
+
+  memset(pad, 0, sizeof(pad));
+  pad[0] = 0x80;
+
+  index = (size_t)((ctx->count >> 3) & 0x3f);
+  pad_len = (index < 56) ? (56 - index) : (120 - index);
+
+  for (i = 0; i < 8; i++)
+    {
+      len_bytes[7 - i] = (uint8_t)(ctx->count >> (i * 8));
+    }
+
+  sha1_update(ctx, pad, pad_len);
+  sha1_update(ctx, len_bytes, 8);
+
+  for (i = 0; i < 5; i++)
+    {
+      digest[i * 4] = (uint8_t)(ctx->state[i] >> 24);
+      digest[i * 4 + 1] = (uint8_t)(ctx->state[i] >> 16);
+      digest[i * 4 + 2] = (uint8_t)(ctx->state[i] >> 8);
+      digest[i * 4 + 3] = (uint8_t)(ctx->state[i]);
+    }
+}
+
+static void base64_encode(const uint8_t *src, size_t len, char *dst,
+                          size_t dst_len)
+{
+  static const char table[] =
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  size_t i;
+  size_t o = 0;
+
+  for (i = 0; i < len && o + 4 < dst_len; i += 3)
+    {
+      uint32_t a = src[i];
+      uint32_t b = (i + 1 < len) ? src[i + 1] : 0;
+      uint32_t c = (i + 2 < len) ? src[i + 2] : 0;
+
+      dst[o++] = table[(a >> 2) & 0x3f];
+      dst[o++] = table[((a & 0x3) << 4) | ((b >> 4) & 0x0f)];
+      if (i + 1 < len)
+        {
+          dst[o++] = table[((b & 0x0f) << 2) | ((c >> 6) & 0x03)];
+        }
+      else
+        {
+          dst[o++] = '=';
+        }
+      if (i + 2 < len)
+        {
+          dst[o++] = table[c & 0x3f];
+        }
+      else
+        {
+          dst[o++] = '=';
+        }
+    }
+
+  if (o < dst_len)
+    {
+      dst[o] = '\0';
+    }
+}
+
+static int parse_ws_url(const char *url, struct ws_url_s *out)
+{
+  const char *host_start;
+  const char *path_start;
+  const char *port_start;
+  size_t host_len;
+  size_t path_len;
+
+  if (url == NULL || out == NULL)
+    {
+      return -EINVAL;
+    }
+
+  memset(out, 0, sizeof(*out));
+
+  if (strncmp(url, "ws://", 5) == 0)
+    {
+      out->port = 80;
+      out->tls = false;
+      host_start = url + 5;
+    }
+  else if (strncmp(url, "wss://", 6) == 0)
+    {
+      out->port = 443;
+      out->tls = true;
+      host_start = url + 6;
+    }
+  else
+    {
+      return -EINVAL;
+    }
+
+  path_start = strchr(host_start, '/');
+  if (path_start == NULL)
+    {
+      path_start = host_start + strlen(host_start);
+    }
+
+  port_start = memchr(host_start, ':', (size_t)(path_start - host_start));
+  if (port_start != NULL)
+    {
+      host_len = (size_t)(port_start - host_start);
+      out->port = (uint16_t)strtoul(port_start + 1, NULL, 10);
+    }
+  else
+    {
+      host_len = (size_t)(path_start - host_start);
+    }
+
+  if (host_len == 0 || host_len >= sizeof(out->host))
+    {
+      return -EINVAL;
+    }
+
+  memcpy(out->host, host_start, host_len);
+  out->host[host_len] = '\0';
+
+  if (*path_start == '\0')
+    {
+      strcpy(out->path, "/");
+    }
+  else
+    {
+      path_len = strlen(path_start);
+      if (path_len >= sizeof(out->path))
+        {
+          return -EINVAL;
+        }
+      memcpy(out->path, path_start, path_len + 1);
+    }
+
+  return 0;
+}
+
+static int tcp_connect(const char *host, uint16_t port, int timeout_ms)
+{
+  struct addrinfo hints;
+  struct addrinfo *res = NULL;
+  struct addrinfo *it;
+  char port_str[8];
+  int fd = -1;
+  int ret;
+
+  snprintf(port_str, sizeof(port_str), "%u", port);
+  memset(&hints, 0, sizeof(hints));
+  hints.ai_family = AF_UNSPEC;
+  hints.ai_socktype = SOCK_STREAM;
+
+  ret = getaddrinfo(host, port_str, &hints, &res);
+  if (ret != 0)
+    {
+      return -EHOSTUNREACH;
+    }
+
+  for (it = res; it != NULL; it = it->ai_next)
+    {
+      struct timeval tv;
+
+      fd = socket(it->ai_family, it->ai_socktype, it->ai_protocol);
+      if (fd < 0)
+        {
+          continue;
+        }
+
+      tv.tv_sec = timeout_ms / 1000;
+      tv.tv_usec = (timeout_ms % 1000) * 1000;
+      setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+      setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+
+      ret = connect(fd, it->ai_addr, it->ai_addrlen);
+      if (ret == 0)
+        {
+          break;
+        }
+
+      close(fd);
+      fd = -1;
+    }
+
+  freeaddrinfo(res);
+  return fd;
+}
+
+#ifdef CONFIG_CRYPTO_MBEDTLS
+
+/* Cached DNS results for dashscope host, resolved in main thread */
+
+#define WS_DNS_MAX_ADDRS 8
+static struct sockaddr_in g_ws_cached_addrs[WS_DNS_MAX_ADDRS];
+static int g_ws_cached_count = 0;
+
+/* Call from main thread before WebSocket thread starts */
+
+void bailian_ws_dns_prefetch(const char *host, uint16_t port)
+{
+  struct addrinfo hints;
+  struct addrinfo *res = NULL;
+  struct addrinfo *it;
+  int ret;
+  char port_str[8];
+
+  snprintf(port_str, sizeof(port_str), "%u", port);
+  memset(&hints, 0, sizeof(hints));
+  hints.ai_family = AF_INET;
+  hints.ai_socktype = SOCK_STREAM;
+
+
+  ret = getaddrinfo(host, port_str, &hints, &res);
+  if (ret == 0 && res != NULL)
+    {
+      g_ws_cached_count = 0;
+      for (it = res; it != NULL && g_ws_cached_count < WS_DNS_MAX_ADDRS;
+           it = it->ai_next)
+        {
+          if (it->ai_family == AF_INET)
+            {
+              memcpy(&g_ws_cached_addrs[g_ws_cached_count],
+                     it->ai_addr, sizeof(struct sockaddr_in));
+              g_ws_cached_count++;
+            }
+        }
+
+      freeaddrinfo(res);
+    }
+  else
+    {
+      printf("[DNS] Pre-resolve failed: %d\n", ret);
+      fflush(stdout);
+    }
+}
+
+/* Helper struct and thread function for connect with timeout.
+ * NuttX connect() blocks even with O_NONBLOCK/SOCK_NONBLOCK set
+ * (FDCHECK encoded fds break non-blocking connect).
+ * Use a helper thread to do blocking connect, with polling
+ * sem_trywait for timeout (sem_timedwait may also block on NuttX).
+ */
+
+struct connect_helper_s
+{
+  int fd;
+  struct sockaddr_in addr;
+  volatile int result;
+  volatile int err;
+  volatile bool done;
+};
+
+static void *connect_thread_func(void *arg)
+{
+  struct connect_helper_s *h = (struct connect_helper_s *)arg;
+
+  h->result = connect(h->fd, (struct sockaddr *)&h->addr, sizeof(h->addr));
+  h->err = errno;
+  h->done = true;
+  return NULL;
+}
+
+/* Force IPv4 connect using cached DNS, try all addresses.
+ * Uses a helper thread + polling for connect timeout,
+ * because NuttX connect() ignores O_NONBLOCK with FDCHECK.
+ */
+
+static int tls_tcp_connect_ipv4(const char *host, uint16_t port,
+                                int timeout_ms)
+{
+  int fd;
+  int i;
+
+  if (g_ws_cached_count <= 0)
+    {
+      printf("[TLS] No cached DNS for %s\n", host);
+      return -EHOSTUNREACH;
+    }
+
+  for (i = 0; i < g_ws_cached_count; i++)
+    {
+      struct connect_helper_s helper;
+      pthread_t tid;
+      int ret;
+      int waited_ms;
+
+      memcpy(&helper.addr, &g_ws_cached_addrs[i], sizeof(helper.addr));
+      helper.addr.sin_port = htons(port);
+      helper.result = -1;
+      helper.err = 0;
+      helper.done = false;
+
+
+      fd = socket(AF_INET, SOCK_STREAM, 0);
+      if (fd < 0)
+        {
+          printf("[TLS] socket failed: %d\n", errno);
+          continue;
+        }
+
+
+      helper.fd = fd;
+
+      /* Create detached thread to do blocking connect */
+
+      pthread_attr_t attr;
+      pthread_attr_init(&attr);
+      pthread_attr_setstacksize(&attr, 2048);
+
+      ret = pthread_create(&tid, &attr, connect_thread_func, &helper);
+      pthread_attr_destroy(&attr);
+      if (ret != 0)
+        {
+          printf("[TLS] pthread_create failed: %d\n", ret);
+          close(fd);
+          continue;
+        }
+
+      /* Poll for completion with timeout */
+
+
+      waited_ms = 0;
+      while (!helper.done && waited_ms < timeout_ms)
+        {
+          usleep(50000); /* 50ms intervals */
+          waited_ms += 50;
+        }
+
+      if (!helper.done)
+        {
+          /* Timeout - close fd to unblock the connect thread */
+
+          printf("[TLS] connect timeout on IP #%d after %dms\n",
+                 i, waited_ms);
+          fflush(stdout);
+          close(fd);
+
+          /* Wait a bit for thread to notice the closed fd */
+
+          int extra = 0;
+          while (!helper.done && extra < 2000)
+            {
+              usleep(50000);
+              extra += 50;
+            }
+
+          if (helper.done)
+            {
+              pthread_join(tid, NULL);
+            }
+          else
+            {
+              /* Thread still stuck, detach it to avoid leak */
+
+              printf("[TLS] connect thread still stuck, detaching\n");
+              fflush(stdout);
+              pthread_detach(tid);
+            }
+
+          continue;
+        }
+
+      /* Thread finished - join and check result */
+
+      pthread_join(tid, NULL);
+
+      if (helper.result != 0)
+        {
+          printf("[TLS] connect failed on IP #%d: errno=%d\n",
+                 i, helper.err);
+          close(fd);
+          continue;
+        }
+
+      goto connected;
+    }
+
+  printf("[TLS] All %d IPs failed\n", g_ws_cached_count);
+  return -EHOSTUNREACH;
+
+connected:
+  {
+    struct timeval tv;
+
+    tv.tv_sec = timeout_ms / 1000;
+    tv.tv_usec = (timeout_ms % 1000) * 1000;
+    setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+    setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+  }
+
+  return fd;
+}
+
+/* Custom recv with poll() timeout for NuttX compatibility.
+ * Cannot use select() because FDCHECK encodes fd values beyond FD_SETSIZE,
+ * causing FD_SET() buffer overflow. poll() has no such limitation.
+ */
+
+/* Custom send with poll() + detailed logging for NuttX FDCHECK compatibility.
+ * Replaces mbedtls_net_send to ensure write() actually delivers data
+ * and to diagnose potential FDCHECK issues on the send path.
+ */
+
+static int my_net_send(void *ctx, const unsigned char *buf, size_t len)
+{
+  mbedtls_net_context *net_ctx = (mbedtls_net_context *)ctx;
+  struct pollfd pfd;
+  int ret;
+
+  pfd.fd = net_ctx->fd;
+  pfd.events = POLLOUT;
+  pfd.revents = 0;
+
+  ret = poll(&pfd, 1, 10000); /* 10 second timeout */
+
+  if (ret == 0)
+    {
+
+    }
+
+  if (ret < 0)
+    {
+      printf("[TLS-SEND] poll error=%d, fd=%d\n", errno, net_ctx->fd);
+      return MBEDTLS_ERR_NET_SEND_FAILED;
+    }
+
+  if (pfd.revents & (POLLERR | POLLHUP))
+    {
+      printf("[TLS-SEND] poll POLLERR/HUP revents=0x%x, fd=%d\n",
+             pfd.revents, net_ctx->fd);
+      return MBEDTLS_ERR_NET_CONN_RESET;
+    }
+
+  ret = (int)write(net_ctx->fd, buf, len);
+
+
+  if (ret < 0)
+    {
+      printf("[TLS-SEND] write errno=%d\n", errno);
+      if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR)
+        {
+          return MBEDTLS_ERR_SSL_WANT_WRITE;
+        }
+
+      if (errno == EPIPE || errno == ECONNRESET)
+        {
+          return MBEDTLS_ERR_NET_CONN_RESET;
+        }
+
+      return MBEDTLS_ERR_NET_SEND_FAILED;
+    }
+
+  return ret;
+}
+
+static int my_net_recv(void *ctx, unsigned char *buf, size_t len)
+{
+  mbedtls_net_context *net_ctx = (mbedtls_net_context *)ctx;
+  struct pollfd pfd;
+  int ret;
+
+  pfd.fd = net_ctx->fd;
+  pfd.events = POLLIN;
+  pfd.revents = 0;
+
+
+  ret = poll(&pfd, 1, 10000); /* 10 second timeout */
+
+  if (ret == 0)
+    {
+
+    }
+
+  if (ret < 0)
+    {
+      printf("[TLS-RECV] poll error=%d, fd=%d\n", errno, net_ctx->fd);
+      return MBEDTLS_ERR_NET_RECV_FAILED;
+    }
+
+  if (pfd.revents & (POLLERR | POLLHUP))
+    {
+      printf("[TLS-RECV] poll POLLERR/HUP revents=0x%x, fd=%d\n",
+             pfd.revents, net_ctx->fd);
+      return MBEDTLS_ERR_NET_CONN_RESET;
+    }
+
+
+  ret = (int)read(net_ctx->fd, buf, len);
+
+
+  if (ret < 0)
+    {
+      if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR)
+        {
+          return MBEDTLS_ERR_SSL_WANT_READ;
+        }
+
+      if (errno == EPIPE || errno == ECONNRESET)
+        {
+          return MBEDTLS_ERR_NET_CONN_RESET;
+        }
+
+      return MBEDTLS_ERR_NET_RECV_FAILED;
+    }
+
+  if (ret == 0)
+    {
+      printf("[TLS-RECV] read returned 0 (connection closed by peer)\n");
+    }
+
+  return ret;
+}
+
+static int tls_connect(struct ws_tls_s *tls, const char *host,
+                       uint16_t port, int timeout_ms)
+{
+  int ret;
+  int fd;
+
+  mbedtls_net_init(&tls->net);
+  mbedtls_ssl_init(&tls->ssl);
+  mbedtls_ssl_config_init(&tls->conf);
+  mbedtls_ctr_drbg_init(&tls->ctr_drbg);
+  mbedtls_entropy_init(&tls->entropy);
+  mbedtls_x509_crt_init(&tls->cacert);
+
+  /* Load GlobalSign Root CA - R3 certificate */
+
+  ret = mbedtls_x509_crt_parse(&tls->cacert,
+                                (const unsigned char *)globalsign_root_r3_pem,
+                                sizeof(globalsign_root_r3_pem));
+  if (ret != 0)
+    {
+      printf("[TLS] CA cert parse failed: -0x%x\n", -ret);
+      return -EIO;
+    }
+
+
+
+  ret = mbedtls_ctr_drbg_seed(&tls->ctr_drbg, mbedtls_entropy_func,
+                              &tls->entropy, (const unsigned char *)"bailian",
+                              strlen("bailian"));
+  if (ret != 0)
+    {
+      return -EIO;
+    }
+
+
+
+  /* Use custom IPv4-only connect instead of mbedtls_net_connect */
+  fd = tls_tcp_connect_ipv4(host, port, timeout_ms);
+  if (fd < 0)
+    {
+      printf("[TLS] TCP connect failed: %d\n", fd);
+      return -EHOSTUNREACH;
+    }
+  tls->net.fd = fd;
+
+
+  ret = mbedtls_ssl_config_defaults(&tls->conf, MBEDTLS_SSL_IS_CLIENT,
+                                    MBEDTLS_SSL_TRANSPORT_STREAM,
+                                    MBEDTLS_SSL_PRESET_DEFAULT);
+
+  if (ret != 0)
+    {
+      return -EIO;
+    }
+  #ifdef CONFIG_MBEDTLS_DEBUG_C
+  mbedtls_ssl_conf_dbg(&tls->conf, my_debug, NULL);
+  mbedtls_debug_set_threshold(4);
+#endif
+
+  /* Configure CA certificate chain and set verification to OPTIONAL
+   * so we can see verification result but still connect if it fails
+   */
+
+  mbedtls_ssl_conf_ca_chain(&tls->conf, &tls->cacert, NULL);
+  mbedtls_ssl_conf_authmode(&tls->conf, MBEDTLS_SSL_VERIFY_OPTIONAL);
+
+
+  mbedtls_ssl_conf_rng(&tls->conf, mbedtls_ctr_drbg_random, &tls->ctr_drbg);
+  if (timeout_ms > 0)
+    {
+      mbedtls_ssl_conf_read_timeout(&tls->conf, timeout_ms);
+    }
+  ret = mbedtls_ssl_setup(&tls->ssl, &tls->conf);
+
+  if (ret != 0)
+    {
+      return -EIO;
+    }
+  ret = mbedtls_ssl_set_hostname(&tls->ssl, host);
+
+  if (ret != 0)
+    {
+      return -EIO;
+    }
+
+  mbedtls_ssl_set_bio(&tls->ssl, &tls->net, my_net_send,
+                      my_net_recv, NULL);
+
+  int hs_count = 0;
+  do
+    {
+
+      ret = mbedtls_ssl_handshake(&tls->ssl);
+
+      hs_count++;
+    }
+  while (ret == MBEDTLS_ERR_SSL_WANT_READ ||
+         ret == MBEDTLS_ERR_SSL_WANT_WRITE);
+
+  if (ret != 0)
+    {
+      printf("[TLS] Handshake failed: -0x%x\n", -ret);
+
+      /* Print verification result if available */
+
+      uint32_t flags = mbedtls_ssl_get_verify_result(&tls->ssl);
+      if (flags != 0)
+        {
+          char vrfy_buf[256];
+          mbedtls_x509_crt_verify_info(vrfy_buf, sizeof(vrfy_buf),
+                                       "  ! ", flags);
+          printf("[TLS] Verify result: %s\n", vrfy_buf);
+        }
+
+      fflush(stdout);
+      return -EIO;
+    }
+
+  /* Print verification result on success too */
+
+  {
+    uint32_t flags = mbedtls_ssl_get_verify_result(&tls->ssl);
+    if (flags != 0)
+      {
+        char vrfy_buf[256];
+        mbedtls_x509_crt_verify_info(vrfy_buf, sizeof(vrfy_buf),
+                                     "  ! ", flags);
+        printf("[TLS] WARNING verify: %s\n", vrfy_buf);
+      }
+    else
+      {
+        printf("[TLS] Server certificate verified OK\n");
+      }
+    
+    fflush(stdout);
+  }
+
+  tls->inited = true;
+  return 0;
+}
+
+static void tls_close(struct ws_tls_s *tls)
+{
+  if (tls == NULL || !tls->inited)
+    {
+      return;
+    }
+
+  mbedtls_ssl_close_notify(&tls->ssl);
+  mbedtls_net_free(&tls->net);
+  mbedtls_ssl_free(&tls->ssl);
+  mbedtls_ssl_config_free(&tls->conf);
+  mbedtls_ctr_drbg_free(&tls->ctr_drbg);
+  mbedtls_entropy_free(&tls->entropy);
+  mbedtls_x509_crt_free(&tls->cacert);
+  tls->inited = false;
+}
+
+static ssize_t tls_write(struct ws_tls_s *tls, const uint8_t *data, size_t len)
+{
+  size_t sent = 0;
+
+  while (sent < len)
+    {
+      int ret = mbedtls_ssl_write(&tls->ssl, data + sent, len - sent);
+      if (ret < 0)
+        {
+          if (ret == MBEDTLS_ERR_SSL_WANT_READ ||
+              ret == MBEDTLS_ERR_SSL_WANT_WRITE)
+            {
+              continue;
+            }
+          return -EIO;
+        }
+      sent += (size_t)ret;
+    }
+
+  return (ssize_t)sent;
+}
+
+static ssize_t tls_read(struct ws_tls_s *tls, uint8_t *data, size_t len)
+{
+  int ret = mbedtls_ssl_read(&tls->ssl, data, len);
+  if (ret == MBEDTLS_ERR_SSL_WANT_READ || ret == MBEDTLS_ERR_SSL_WANT_WRITE)
+    {
+      return 0;
+    }
+  if (ret == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY)
+    {
+      return 0;
+    }
+  if (ret < 0)
+    {
+      return -EIO;
+    }
+  return ret;
+}
+#endif
+
+static ssize_t ws_write(struct bailian_ws_client *client, const uint8_t *data,
+                        size_t len)
+{
+  if (client->tls)
+    {
+#ifdef CONFIG_CRYPTO_MBEDTLS
+      return tls_write(&client->tls_ctx, data, len);
+#else
+      return -ENOTSUP;
+#endif
+    }
+
+  return send(client->fd, data, len, 0);
+}
+
+/* Single read attempt — may return fewer bytes than requested */
+static ssize_t ws_read_once(struct bailian_ws_client *client, uint8_t *data,
+                            size_t len, int timeout_ms)
+{
+  if (client->tls)
+    {
+#ifdef CONFIG_CRYPTO_MBEDTLS
+      return tls_read(&client->tls_ctx, data, len);
+#else
+      return -ENOTSUP;
+#endif
+    }
+  if (timeout_ms > 0)
+    {
+      struct pollfd pfd;
+      pfd.fd = client->fd;
+      pfd.events = POLLIN;
+      pfd.revents = 0;
+      if (poll(&pfd, 1, timeout_ms) <= 0)
+        {
+          return 0;
+        }
+    }
+  return recv(client->fd, data, len, 0);
+}
+
+/* Read exactly 'len' bytes, looping for partial TLS reads.
+ * mbedtls_ssl_read may return fewer bytes than requested
+ * (e.g. request 8000, get 4096 from one TLS record).
+ * Returns len on success, <= 0 on error/timeout. */
+static ssize_t ws_read_exact(struct bailian_ws_client *client, uint8_t *data,
+                             size_t len, int timeout_ms)
+{
+  size_t total = 0;
+  while (total < len)
+    {
+      ssize_t ret = ws_read_once(client, data + total, len - total, timeout_ms);
+      if (ret < 0)
+        {
+          return ret;
+        }
+      if (ret == 0)
+        {
+          if (total == 0) return 0;  /* timeout before any data */
+          /* Got partial data, keep trying */
+          usleep(1000);
+          continue;
+        }
+      total += (size_t)ret;
+    }
+  return (ssize_t)total;
+}
+
+static int ws_build_accept(const char *key, char *accept, size_t accept_len)
+{
+  char concat[128];
+  uint8_t digest[20];
+  sha1_ctx_t ctx;
+
+  if (snprintf(concat, sizeof(concat), "%s%s", key, WS_GUID) < 0)
+    {
+      return -EINVAL;
+    }
+
+  sha1_init(&ctx);
+  sha1_update(&ctx, (const uint8_t *)concat, strlen(concat));
+  sha1_final(&ctx, digest);
+  base64_encode(digest, sizeof(digest), accept, accept_len);
+  return 0;
+}
+
+void bailian_ws_close(struct bailian_ws_client *client);
+
+int bailian_ws_connect(const char *url, const char *extra_headers,
+                       int timeout_ms, struct bailian_ws_client **out)
+{
+  struct ws_url_s parsed;
+  struct bailian_ws_client *client;
+  uint8_t key_raw[16];
+  char key_b64[64];
+  char accept[64];
+  char request[512];
+  char response[512];
+  ssize_t ret;
+
+  if (parse_ws_url(url, &parsed) != 0 || out == NULL)
+    {
+      printf("[WS] URL parse failed\n");
+      return -EINVAL;
+    }
+
+  client = calloc(1, sizeof(*client));
+  if (client == NULL)
+    {
+      printf("[WS] calloc failed\n");
+      return -ENOMEM;
+    }
+
+  client->tls = parsed.tls;
+
+  if (parsed.tls)
+    {
+#ifdef CONFIG_CRYPTO_MBEDTLS
+      ret = tls_connect(&client->tls_ctx, parsed.host, parsed.port, timeout_ms);
+      if (ret < 0)
+        {
+          free(client);
+          return (int)ret;
+        }
+#else
+      free(client);
+      return -ENOTSUP;
+#endif
+    }
+  else
+    {
+      client->fd = tcp_connect(parsed.host, parsed.port, timeout_ms);
+      if (client->fd < 0)
+        {
+          free(client);
+          return client->fd;
+        }
+    }
+
+  for (size_t i = 0; i < sizeof(key_raw); i++)
+    {
+      key_raw[i] = (uint8_t)(rand() & 0xff);
+    }
+  base64_encode(key_raw, sizeof(key_raw), key_b64, sizeof(key_b64));
+  ws_build_accept(key_b64, accept, sizeof(accept));
+
+  snprintf(request, sizeof(request),
+           "GET %s HTTP/1.1\r\n"
+           "Host: %s\r\n"
+           "Upgrade: websocket\r\n"
+           "Connection: Upgrade\r\n"
+           "Sec-WebSocket-Key: %s\r\n"
+           "Sec-WebSocket-Version: 13\r\n"
+           "%s\r\n",
+           parsed.path, parsed.host, key_b64,
+           extra_headers != NULL ? extra_headers : "");
+
+  ret = ws_write(client, (const uint8_t *)request, strlen(request));
+  if (ret < 0)
+    {
+      bailian_ws_close(client);
+      return (int)ret;
+    }
+
+  ret = ws_read_once(client, (uint8_t *)response, sizeof(response) - 1, timeout_ms);
+  if (ret <= 0)
+    {
+      bailian_ws_close(client);
+      return -EIO;
+    }
+
+  response[ret] = '\0';
+  if (strstr(response, " 101 ") == NULL ||
+      strcasestr(response, "Sec-WebSocket-Accept") == NULL ||
+      strstr(response, accept) == NULL)
+    {
+      bailian_ws_close(client);
+      return -EPROTO;
+    }
+
+  *out = client;
+  return 0;
+}
+
+int bailian_ws_send(struct bailian_ws_client *client, uint8_t opcode,
+                    const uint8_t *data, size_t len)
+{
+  uint8_t header[14];
+  uint8_t mask[4];
+  size_t header_len = 0;
+  size_t i;
+
+  if (client == NULL)
+    {
+      return -EINVAL;
+    }
+
+  header[0] = 0x80 | (opcode & 0x0f);
+  if (len < 126)
+    {
+      header[1] = 0x80 | (uint8_t)len;
+      header_len = 2;
+    }
+  else if (len < 65536)
+    {
+      header[1] = 0x80 | 126;
+      header[2] = (uint8_t)(len >> 8);
+      header[3] = (uint8_t)(len & 0xff);
+      header_len = 4;
+    }
+  else
+    {
+      header[1] = 0x80 | 127;
+      for (i = 0; i < 8; i++)
+        {
+          header[2 + i] = (uint8_t)((len >> ((7 - i) * 8)) & 0xff);
+        }
+      header_len = 10;
+    }
+
+  for (i = 0; i < 4; i++)
+    {
+      mask[i] = (uint8_t)(rand() & 0xff);
+    }
+
+  memcpy(&header[header_len], mask, 4);
+  header_len += 4;
+
+  if (ws_write(client, header, header_len) < 0)
+    {
+      return -EIO;
+    }
+
+  if (len > 0)
+    {
+      uint8_t *masked = malloc(len);
+      if (masked == NULL)
+        {
+          return -ENOMEM;
+        }
+      for (i = 0; i < len; i++)
+        {
+          masked[i] = data[i] ^ mask[i % 4];
+        }
+      if (ws_write(client, masked, len) < 0)
+        {
+          free(masked);
+          return -EIO;
+        }
+      free(masked);
+    }
+
+  return 0;
+}
+
+int bailian_ws_recv(struct bailian_ws_client *client, uint8_t *opcode,
+                    uint8_t *data, size_t len, int timeout_ms)
+{
+  uint8_t header[2];
+  uint8_t ext_len[8];
+  size_t payload_len;
+  int masked;
+  ssize_t ret;
+
+  if (client == NULL || opcode == NULL || data == NULL)
+    {
+      return -EINVAL;
+    }
+
+  ret = ws_read_once(client, header, sizeof(header), timeout_ms);
+  if (ret <= 0)
+    {
+      return (int)ret;
+    }
+
+  *opcode = header[0] & 0x0f;
+  masked = (header[1] & 0x80) != 0;
+  payload_len = (header[1] & 0x7f);
+
+  if (payload_len == 126)
+    {
+      ret = ws_read_exact(client, ext_len, 2, timeout_ms);
+      if (ret != 2)
+        {
+          return -EIO;
+        }
+      payload_len = ((size_t)ext_len[0] << 8) | ext_len[1];
+    }
+  else if (payload_len == 127)
+    {
+      ret = ws_read_exact(client, ext_len, 8, timeout_ms);
+      if (ret != 8)
+        {
+          return -EIO;
+        }
+      payload_len = 0;
+      for (int i = 0; i < 8; i++)
+        {
+          payload_len = (payload_len << 8) | ext_len[i];
+        }
+    }
+
+  if (payload_len > len)
+    {
+      /* Frame too large for buffer — drain it to keep stream in sync */
+      printf("[WS] frame too large: %zu > %zu, draining\n",
+             payload_len, len);
+      size_t skip = payload_len + (masked ? 4 : 0);
+      uint8_t drain[512];
+      while (skip > 0)
+        {
+          size_t chunk = skip < sizeof(drain) ? skip : sizeof(drain);
+          ret = ws_read_once(client, drain, chunk, timeout_ms);
+          if (ret <= 0)
+            {
+              return -EIO;  /* Connection broken during drain */
+            }
+          skip -= (size_t)ret;
+        }
+      return 0;  /* Frame skipped, not an error */
+    }
+
+  if (masked)
+    {
+      uint8_t mask[4];
+      ret = ws_read_exact(client, mask, sizeof(mask), timeout_ms);
+      if (ret != 4)
+        {
+          return -EIO;
+        }
+
+      ret = ws_read_exact(client, data, payload_len, timeout_ms);
+      if (ret != (ssize_t)payload_len)
+        {
+          return -EIO;
+        }
+
+      for (size_t i = 0; i < payload_len; i++)
+        {
+          data[i] ^= mask[i % 4];
+        }
+    }
+  else
+    {
+      ret = ws_read_exact(client, data, payload_len, timeout_ms);
+      if (ret != (ssize_t)payload_len)
+        {
+          return -EIO;
+        }
+    }
+
+  if (*opcode == 0x9)
+    {
+      bailian_ws_send(client, 0xA, data, payload_len);
+      return 0;
+    }
+
+  return (int)payload_len;
+}
+
+void bailian_ws_close(struct bailian_ws_client *client)
+{
+  if (client == NULL)
+    {
+      return;
+    }
+
+  if (client->tls)
+    {
+#ifdef CONFIG_CRYPTO_MBEDTLS
+      tls_close(&client->tls_ctx);
+#endif
+    }
+  else if (client->fd >= 0)
+    {
+      close(client->fd);
+    }
+
+  free(client);
+}


### PR DESCRIPTION
## Summary

Add Bailian (百炼 / Model Studio) real-time voice interaction demo for openvela goldfish-armeabi-v7a-ap emulator. Supports full ASR → LLM → TTS pipeline via virtio-snd audio device.

## Changes

- `bailian/bailian_main.c`: Main application with WebSocket communication, push-to-talk voice interaction
- `bailian/audio/recorder.c`: Microphone capture via virtio-snd with PulseAudio warmup
- `bailian/audio/player.c`: TTS playback with 24kHz→48kHz upsampling for virtio-snd compatibility
- `bailian/net/websocket.c`: TLS WebSocket client for DashScope server
- `bailian/hal/`: SDK HAL layer implementation (memory, mutex, time, storage, random) for NuttX
- `bailian/bailian_sdk/`: Alibaba Bailian SDK v1.1.0 (Apache-2.0, prebuilt libraries + headers)
- `bailian/Kconfig`: Configuration options (API key, workspace ID, app ID, device paths)
- `bailian/README.md`: Setup guide with defconfig configuration and usage instructions

## How to use

See `bailian/README.md` for full instructions. Key steps:
1. Add `CONFIG_AI_BAILIAN=y` and credential configs to defconfig
2. Build with `./build.sh vendor/openvela/boards/vela/configs/goldfish-armeabi-v7a-ap --cmake`
3. Start emulator with PA environment variables for USB mic/speaker
4. Run `bailian` in NSH, press `t` to talk, `s` to stop

## License

- Adaptation code: Apache-2.0 (openvela)
- Bailian SDK (`bailian_sdk/`): Apache-2.0 (Copyright 2025 Alibaba Group Holding Ltd.)
- Third-party: cJSON (MIT), tinycrypt (BSD-3-Clause)