### PR TITLE
bailian: replace bundled cJSON with system library

### DIFF
--- a/bailian/CMakeLists.txt
+++ b/bailian/CMakeLists.txt
@@ -43,7 +43,8 @@ if(CONFIG_AI_BAILIAN)
   target_sources(bailian_hal PRIVATE ${HAL_SRCS})
   target_include_directories(bailian_hal PRIVATE
     ${BAILIAN_SDK_DIR}/include
-    ${BAILIAN_SDK_DIR}/include/c_utils)
+    ${BAILIAN_SDK_DIR}/include/c_utils
+    ${NUTTX_APPS_DIR}/netutils/cjson/cJSON)
 
   # Create the main application
   nuttx_add_application(
@@ -60,7 +61,7 @@ if(CONFIG_AI_BAILIAN)
     INCLUDE_DIRECTORIES
     ${BAILIAN_SDK_DIR}/include
     ${BAILIAN_SDK_DIR}/include/c_utils
-    ${BAILIAN_SDK_DIR}/third_party/cJSON
+    ${NUTTX_APPS_DIR}/netutils/cjson/cJSON
     ${BAILIAN_SDK_DIR}/third_party/tinycrypt/include)
 
   # Link SDK libraries with HAL library using whole-archive to ensure all HAL symbols are included
@@ -74,7 +75,6 @@ if(CONFIG_AI_BAILIAN)
     # libc_license.a removed - using pay-as-you-go mode
     ${BAILIAN_SDK_DIR}/libs/libc_mmi_cmd.a
     ${BAILIAN_SDK_DIR}/libs/libqwen_test.a
-    ${BAILIAN_SDK_DIR}/third_party/cJSON/libcjson.a
     ${BAILIAN_SDK_DIR}/third_party/tinycrypt/libtinycrypt.a
     -Wl,--end-group)
 

--- a/bailian/Kconfig
+++ b/bailian/Kconfig
@@ -3,6 +3,7 @@ config AI_BAILIAN
 	default n
 	select AUDIOUTILS_NXAUDIO
 	select SYSTEM_NXRECORDER
+	select NETUTILS_CJSON
 	---help---
 		Enable the openvela Bailian SDK adaptation example.
 


### PR DESCRIPTION
## Summary

- Replace SDK's bundled cJSON (`third_party/cJSON`) with the system cJSON library (`apps/netutils/cjson`)
- Add `select NETUTILS_CJSON` to Kconfig to auto-enable system cJSON
- Update CMakeLists.txt include paths accordingly

Note: tinycrypt is kept from the SDK's `third_party/` because the SDK's pre-built static libraries are compiled against its bundled version. Using the system tinycrypt causes silent encryption failures (server returns `ClientAudioTimeout`).

Depends on: https://github.com/open-vela/external_bailian_sdk/pull/2

## Impact

- cJSON dependency changes from SDK-bundled to system library
- No functional change

## Testing

- Build verified with `./build.sh vendor/openvela/boards/vela/configs/goldfish-armeabi-v7a-ap --cmake`
- Runtime verified on goldfish-armeabi-v7a-ap emulator: full ASR → LLM → TTS pipeline working correctly with system cJSON

Signed-off-by: v-yanxingyu <v-yanxingyu@xiaomi.com>