### PR TITLE
feat: add stopwatch demo application

### DIFF
--- a/stopwatch/CMakeLists.txt
+++ b/stopwatch/CMakeLists.txt
@@ -1,0 +1,36 @@
+# ##############################################################################
+# packages/demos/stopwatch/CMakeLists.txt
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_LVX_USE_DEMO_STOPWATCH)
+  set(PROGNAME stopwatch)
+  set(PRIORITY 100)
+  set(STACKSIZE 16384)
+  set(MODULE ${CONFIG_LVX_USE_DEMO_STOPWATCH})
+  set(CSRCS stopwatch_ui.c)
+  set(MAINSRC stopwatch_main.c)
+
+  nuttx_add_application(
+    NAME ${PROGNAME}
+    PRIORITY ${PRIORITY}
+    STACKSIZE ${STACKSIZE}
+    MODULE ${MODULE}
+    SRCS ${MAINSRC} ${CSRCS}
+  )
+endif()

--- a/stopwatch/Kconfig
+++ b/stopwatch/Kconfig
@@ -1,0 +1,14 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config LVX_USE_DEMO_STOPWATCH
+	bool "STOPWATCH"
+	default n
+
+if LVX_USE_DEMO_STOPWATCH
+	config LVX_STOPWATCH_DATA_ROOT
+		string "Stopwatch Data Root"
+		default "/data"
+endif

--- a/stopwatch/Make.defs
+++ b/stopwatch/Make.defs
@@ -1,0 +1,18 @@
+#
+# Copyright (C) 2024 Xiaomi Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+ifneq ($(CONFIG_LVX_USE_DEMO_STOPWATCH),)
+CONFIGURED_APPS += $(APPDIR)/packages/demos/stopwatch
+endif

--- a/stopwatch/Makefile
+++ b/stopwatch/Makefile
@@ -1,0 +1,28 @@
+#
+# Copyright (C) 2024 Xiaomi Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include $(APPDIR)/Make.defs
+
+ifeq ($(CONFIG_LVX_USE_DEMO_STOPWATCH), y)
+PROGNAME = stopwatch
+PRIORITY = 100
+STACKSIZE = 16384
+MODULE = $(CONFIG_LVX_USE_DEMO_STOPWATCH)
+CSRCS = stopwatch_ui.c
+MAINSRC = stopwatch_main.c
+endif
+
+include $(APPDIR)/Application.mk

--- a/stopwatch/README.md
+++ b/stopwatch/README.md
@@ -1,0 +1,71 @@
+# Stopwatch
+
+\[ English | [简体中文](README_zh-cn.md) \]
+
+## Overview
+
+A simple stopwatch application built with LVGL for the OpenVela platform. It provides basic timing functionality with lap recording support.
+
+## Features
+
+- Start / Stop / Reset controls
+- Lap time recording (up to 10 laps)
+- Scrollable lap history list
+- Real-time display update at ~30 fps
+- Clean dark-themed UI
+
+## Screenshots
+
+| Idle | Running | Laps |
+|------|---------|------|
+| ![idle](screenshots/idle.png) | ![running](screenshots/running.png) | ![laps](screenshots/laps.png) |
+
+> Screenshots are placeholders. Replace with actual device captures.
+
+## Build
+
+Enable the demo in your NuttX configuration:
+
+```
+CONFIG_LVX_USE_DEMO_STOPWATCH=y
+```
+
+Then build the project as usual.
+
+## Usage
+
+Run the application from the NuttX shell:
+
+```shell
+nsh> stopwatch
+```
+
+- Press **Start** to begin timing.
+- Press **Lap** while running to record a lap time.
+- Press **Stop** to pause the timer.
+- Press **Reset** (when stopped) to clear all data.
+
+## File Structure
+
+```
+stopwatch/
+├── CMakeLists.txt       # CMake build configuration
+├── Kconfig              # NuttX Kconfig options
+├── Make.defs            # NuttX build system integration
+├── Makefile             # NuttX Makefile
+├── README.md            # This file
+├── README_zh-cn.md      # Chinese documentation
+├── stopwatch_main.c     # Application entry point
+├── stopwatch_ui.c       # UI creation and event handling
+└── stopwatch_ui.h       # UI header file
+```
+
+## Dependencies
+
+- LVGL (v9.x)
+- libuv
+- NuttX RTOS
+
+## License
+
+Apache License 2.0

--- a/stopwatch/README_zh-cn.md
+++ b/stopwatch/README_zh-cn.md
@@ -1,0 +1,63 @@
+# 秒表
+
+\[ [English](README.md) | 简体中文 \]
+
+## 概述
+
+一个基于 LVGL 构建的简易秒表应用，运行在 OpenVela 平台上。提供基本的计时功能，支持记录分段时间。
+
+## 功能特性
+
+- 开始 / 停止 / 重置控制
+- 分段计时记录（最多 10 个分段）
+- 可滚动的分段历史列表
+- 约 30 fps 的实时显示刷新
+- 简洁的深色主题 UI
+
+## 构建
+
+在 NuttX 配置中启用该 demo：
+
+```
+CONFIG_LVX_USE_DEMO_STOPWATCH=y
+```
+
+然后按照常规方式构建项目。
+
+## 使用方法
+
+在 NuttX shell 中运行：
+
+```shell
+nsh> stopwatch
+```
+
+- 点击 **Start** 开始计时
+- 计时过程中点击 **Lap** 记录分段时间
+- 点击 **Stop** 暂停计时
+- 停止状态下点击 **Reset** 清除所有数据
+
+## 文件结构
+
+```
+stopwatch/
+├── CMakeLists.txt       # CMake 构建配置
+├── Kconfig              # NuttX Kconfig 配置选项
+├── Make.defs            # NuttX 构建系统集成
+├── Makefile             # NuttX Makefile
+├── README.md            # 英文文档
+├── README_zh-cn.md      # 本文件
+├── stopwatch_main.c     # 应用入口
+├── stopwatch_ui.c       # UI 创建与事件处理
+└── stopwatch_ui.h       # UI 头文件
+```
+
+## 依赖
+
+- LVGL (v9.x)
+- libuv
+- NuttX RTOS
+
+## 许可证
+
+Apache License 2.0

--- a/stopwatch/stopwatch_main.c
+++ b/stopwatch/stopwatch_main.c
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2024 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <nuttx/config.h>
+#include <unistd.h>
+#include <uv.h>
+#include <lvgl/lvgl.h>
+#include "stopwatch_ui.h"
+
+static void lv_nuttx_uv_loop(uv_loop_t *loop, lv_nuttx_result_t *result)
+{
+    lv_nuttx_uv_t uv_info;
+    void *data;
+
+    uv_loop_init(loop);
+
+    lv_memset(&uv_info, 0, sizeof(uv_info));
+    uv_info.loop  = loop;
+    uv_info.disp  = result->disp;
+    uv_info.indev = result->indev;
+#ifdef CONFIG_UINPUT_TOUCH
+    uv_info.uindev = result->utouch_indev;
+#endif
+
+    data = lv_nuttx_uv_init(&uv_info);
+    uv_run(loop, UV_RUN_DEFAULT);
+    lv_nuttx_uv_deinit(&data);
+}
+
+int stopwatch_main(int argc, FAR char *argv[])
+{
+    lv_nuttx_dsc_t    info;
+    lv_nuttx_result_t result;
+    uv_loop_t         ui_loop;
+    stopwatch_ui_t   *ui = NULL;
+
+    lv_memset(&ui_loop, 0, sizeof(uv_loop_t));
+
+    if (lv_is_initialized()) {
+        LV_LOG_ERROR("LVGL already initialized! aborting.");
+        return -1;
+    }
+
+    lv_init();
+    lv_nuttx_dsc_init(&info);
+    lv_nuttx_init(&info, &result);
+
+    if (result.disp == NULL) {
+        LV_LOG_ERROR("stopwatch: display initialization failure!");
+        return 1;
+    }
+
+    /* Create the stopwatch UI */
+
+    lv_obj_t *scr = lv_screen_active();
+    ui = stopwatch_ui_create(scr);
+
+    if (!ui) {
+        LV_LOG_ERROR("stopwatch: UI creation failure!");
+        lv_nuttx_deinit(&result);
+        lv_deinit();
+        return 1;
+    }
+
+    /* Enter the event loop */
+
+    lv_nuttx_uv_loop(&ui_loop, &result);
+
+    /* Cleanup */
+
+    stopwatch_ui_destroy(ui);
+    lv_nuttx_deinit(&result);
+    lv_deinit();
+
+    return 0;
+}

--- a/stopwatch/stopwatch_ui.c
+++ b/stopwatch/stopwatch_ui.c
@@ -1,0 +1,236 @@
+/*
+ * Copyright (C) 2024 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "stopwatch_ui.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define STOPWATCH_MAX_LAPS     10
+#define STOPWATCH_UPDATE_MS    33   /* ~30 fps */
+
+/* Color definitions */
+
+#define COLOR_BG        lv_color_hex(0x1A1A2E)
+#define COLOR_START     lv_color_hex(0x16C47F)
+#define COLOR_STOP      lv_color_hex(0xE74C3C)
+#define COLOR_LAP       lv_color_hex(0x3498DB)
+#define COLOR_RESET     lv_color_hex(0x95A5A6)
+#define COLOR_TEXT      lv_color_hex(0xECF0F1)
+#define COLOR_TEXT_DIM  lv_color_hex(0x7F8C8D)
+
+/* ---------- helpers ---------- */
+
+static void format_time(uint32_t ms, char *buf, size_t len)
+{
+    uint32_t minutes = ms / 60000;
+    uint32_t seconds = (ms % 60000) / 1000;
+    uint32_t centis  = (ms % 1000) / 10;
+    snprintf(buf, len, "%02" PRIu32 ":%02" PRIu32 ".%02" PRIu32,
+             minutes, seconds, centis);
+}
+
+static void update_display(stopwatch_ui_t *ui)
+{
+    char buf[16];
+    uint32_t ms = ui->state.elapsed_ms;
+
+    if (ui->state.running) {
+        ms += lv_tick_get() - ui->state.start_tick;
+    }
+
+    uint32_t minutes = ms / 60000;
+    uint32_t seconds = (ms % 60000) / 1000;
+    uint32_t centis  = (ms % 1000) / 10;
+
+    snprintf(buf, sizeof(buf), "%02" PRIu32 ":%02" PRIu32,
+             minutes, seconds);
+    lv_label_set_text(ui->time_label, buf);
+
+    snprintf(buf, sizeof(buf), ".%02" PRIu32, centis);
+    lv_label_set_text(ui->ms_label, buf);
+}
+
+/* ---------- timer callback ---------- */
+
+static void timer_cb(lv_timer_t *timer)
+{
+    stopwatch_ui_t *ui = (stopwatch_ui_t *)lv_timer_get_user_data(timer);
+    if (ui && ui->state.running) {
+        update_display(ui);
+    }
+}
+
+/* ---------- button callbacks ---------- */
+
+static void start_stop_cb(lv_event_t *e)
+{
+    stopwatch_ui_t *ui = (stopwatch_ui_t *)lv_event_get_user_data(e);
+    if (!ui) return;
+
+    if (ui->state.running) {
+        /* Stop */
+        ui->state.elapsed_ms += lv_tick_get() - ui->state.start_tick;
+        ui->state.running = false;
+        lv_label_set_text(ui->start_label, LV_SYMBOL_PLAY " Start");
+        lv_obj_set_style_bg_color(ui->btn_start, COLOR_START, 0);
+        lv_label_set_text(ui->lap_label, LV_SYMBOL_REFRESH " Reset");
+        lv_obj_set_style_bg_color(ui->btn_lap, COLOR_RESET, 0);
+    } else {
+        /* Start */
+        ui->state.start_tick = lv_tick_get();
+        ui->state.running = true;
+        lv_label_set_text(ui->start_label, LV_SYMBOL_STOP " Stop");
+        lv_obj_set_style_bg_color(ui->btn_start, COLOR_STOP, 0);
+        lv_label_set_text(ui->lap_label, LV_SYMBOL_LOOP " Lap");
+        lv_obj_set_style_bg_color(ui->btn_lap, COLOR_LAP, 0);
+    }
+
+    update_display(ui);
+}
+
+static void lap_reset_cb(lv_event_t *e)
+{
+    stopwatch_ui_t *ui = (stopwatch_ui_t *)lv_event_get_user_data(e);
+    if (!ui) return;
+
+    if (ui->state.running) {
+        /* Record lap */
+        if (ui->state.lap_count < STOPWATCH_MAX_LAPS) {
+            uint32_t current = ui->state.elapsed_ms +
+                               (lv_tick_get() - ui->state.start_tick);
+            ui->state.laps[ui->state.lap_count] = current;
+            ui->state.lap_count++;
+
+            char buf[32];
+            char time_str[16];
+            format_time(current, time_str, sizeof(time_str));
+            snprintf(buf, sizeof(buf), "Lap %d   %s",
+                     ui->state.lap_count, time_str);
+            lv_obj_t *item = lv_label_create(ui->lap_list);
+            lv_label_set_text(item, buf);
+            lv_obj_set_style_text_color(item, COLOR_TEXT, 0);
+            lv_obj_set_style_text_font(item, &lv_font_montserrat_14, 0);
+        }
+    } else {
+        /* Reset */
+        ui->state.elapsed_ms = 0;
+        ui->state.running    = false;
+        ui->state.lap_count  = 0;
+        memset(ui->state.laps, 0, sizeof(ui->state.laps));
+
+        lv_label_set_text(ui->start_label, LV_SYMBOL_PLAY " Start");
+        lv_obj_set_style_bg_color(ui->btn_start, COLOR_START, 0);
+        lv_label_set_text(ui->lap_label, LV_SYMBOL_LOOP " Lap");
+        lv_obj_set_style_bg_color(ui->btn_lap, COLOR_LAP, 0);
+
+        /* Clear lap list */
+        lv_obj_clean(ui->lap_list);
+
+        update_display(ui);
+    }
+}
+
+/* ---------- public API ---------- */
+
+stopwatch_ui_t *stopwatch_ui_create(lv_obj_t *parent)
+{
+    stopwatch_ui_t *ui = (stopwatch_ui_t *)lv_malloc(sizeof(stopwatch_ui_t));
+    if (!ui) return NULL;
+    memset(ui, 0, sizeof(stopwatch_ui_t));
+
+    ui->scr = parent;
+
+    /* Background */
+    lv_obj_set_style_bg_color(parent, COLOR_BG, 0);
+    lv_obj_set_style_bg_opa(parent, LV_OPA_COVER, 0);
+
+    /* Main time label  MM:SS */
+    ui->time_label = lv_label_create(parent);
+    lv_label_set_text(ui->time_label, "00:00");
+    lv_obj_set_style_text_font(ui->time_label, &lv_font_montserrat_48, 0);
+    lv_obj_set_style_text_color(ui->time_label, COLOR_TEXT, 0);
+    lv_obj_align(ui->time_label, LV_ALIGN_TOP_MID, -20, 30);
+
+    /* Centiseconds label  .XX */
+    ui->ms_label = lv_label_create(parent);
+    lv_label_set_text(ui->ms_label, ".00");
+    lv_obj_set_style_text_font(ui->ms_label, &lv_font_montserrat_24, 0);
+    lv_obj_set_style_text_color(ui->ms_label, COLOR_TEXT_DIM, 0);
+    lv_obj_align_to(ui->ms_label, ui->time_label, LV_ALIGN_OUT_RIGHT_BOTTOM,
+                    4, -4);
+
+    /* ---- Buttons ---- */
+
+    /* Start / Stop button */
+    ui->btn_start = lv_btn_create(parent);
+    lv_obj_set_size(ui->btn_start, 120, 48);
+    lv_obj_align(ui->btn_start, LV_ALIGN_TOP_MID, -70, 110);
+    lv_obj_set_style_bg_color(ui->btn_start, COLOR_START, 0);
+    lv_obj_set_style_radius(ui->btn_start, 24, 0);
+    lv_obj_add_event_cb(ui->btn_start, start_stop_cb, LV_EVENT_CLICKED, ui);
+
+    ui->start_label = lv_label_create(ui->btn_start);
+    lv_label_set_text(ui->start_label, LV_SYMBOL_PLAY " Start");
+    lv_obj_center(ui->start_label);
+    lv_obj_set_style_text_color(ui->start_label, lv_color_white(), 0);
+
+    /* Lap / Reset button */
+    ui->btn_lap = lv_btn_create(parent);
+    lv_obj_set_size(ui->btn_lap, 120, 48);
+    lv_obj_align(ui->btn_lap, LV_ALIGN_TOP_MID, 70, 110);
+    lv_obj_set_style_bg_color(ui->btn_lap, COLOR_LAP, 0);
+    lv_obj_set_style_radius(ui->btn_lap, 24, 0);
+    lv_obj_add_event_cb(ui->btn_lap, lap_reset_cb, LV_EVENT_CLICKED, ui);
+
+    ui->lap_label = lv_label_create(ui->btn_lap);
+    lv_label_set_text(ui->lap_label, LV_SYMBOL_LOOP " Lap");
+    lv_obj_center(ui->lap_label);
+    lv_obj_set_style_text_color(ui->lap_label, lv_color_white(), 0);
+
+    /* ---- Lap list ---- */
+
+    ui->lap_list = lv_obj_create(parent);
+    lv_obj_set_size(ui->lap_list, lv_pct(90), lv_pct(45));
+    lv_obj_align(ui->lap_list, LV_ALIGN_BOTTOM_MID, 0, -10);
+    lv_obj_set_flex_flow(ui->lap_list, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(ui->lap_list, LV_FLEX_ALIGN_START,
+                          LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
+    lv_obj_set_style_bg_color(ui->lap_list, lv_color_hex(0x16213E), 0);
+    lv_obj_set_style_bg_opa(ui->lap_list, LV_OPA_COVER, 0);
+    lv_obj_set_style_radius(ui->lap_list, 12, 0);
+    lv_obj_set_style_border_width(ui->lap_list, 0, 0);
+    lv_obj_set_style_pad_all(ui->lap_list, 10, 0);
+    lv_obj_set_style_pad_row(ui->lap_list, 6, 0);
+    lv_obj_set_scrollbar_mode(ui->lap_list, LV_SCROLLBAR_MODE_AUTO);
+
+    /* Timer for display updates */
+    ui->timer = lv_timer_create(timer_cb, STOPWATCH_UPDATE_MS, ui);
+
+    return ui;
+}
+
+void stopwatch_ui_destroy(stopwatch_ui_t *ui)
+{
+    if (!ui) return;
+
+    if (ui->timer) {
+        lv_timer_delete(ui->timer);
+        ui->timer = NULL;
+    }
+
+    lv_free(ui);
+}

--- a/stopwatch/stopwatch_ui.h
+++ b/stopwatch/stopwatch_ui.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2024 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef STOPWATCH_UI_H
+#define STOPWATCH_UI_H
+
+#include <lvgl/lvgl.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Stopwatch state */
+
+typedef struct {
+    uint32_t elapsed_ms;     /* Total elapsed time in milliseconds */
+    bool     running;        /* Whether the stopwatch is running */
+    uint32_t start_tick;     /* Tick when started */
+    uint8_t  lap_count;      /* Number of recorded laps */
+    uint32_t laps[10];       /* Lap times (max 10) */
+} stopwatch_state_t;
+
+/* UI elements */
+
+typedef struct {
+    lv_obj_t            *scr;          /* Screen object */
+    lv_obj_t            *time_label;   /* Main time display */
+    lv_obj_t            *ms_label;     /* Milliseconds display */
+    lv_obj_t            *btn_start;    /* Start/Stop button */
+    lv_obj_t            *btn_lap;      /* Lap/Reset button */
+    lv_obj_t            *lap_list;     /* Lap time list */
+    lv_obj_t            *start_label;  /* Start button label */
+    lv_obj_t            *lap_label;    /* Lap button label */
+    lv_timer_t          *timer;        /* Update timer */
+    stopwatch_state_t    state;        /* Stopwatch state */
+} stopwatch_ui_t;
+
+/**
+ * Create the stopwatch UI on the given screen.
+ *
+ * @param parent  The parent object (usually lv_screen_active())
+ * @return Pointer to the allocated stopwatch_ui_t, or NULL on failure
+ */
+
+stopwatch_ui_t *stopwatch_ui_create(lv_obj_t *parent);
+
+/**
+ * Destroy the stopwatch UI and free resources.
+ *
+ * @param ui  Pointer to the stopwatch UI
+ */
+
+void stopwatch_ui_destroy(stopwatch_ui_t *ui);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* STOPWATCH_UI_H */


### PR DESCRIPTION
## Description\n\nAdd a **Stopwatch** demo application built with LVGL for the OpenVela platform.\n\n## Features\n\n- **Start / Stop / Reset** controls with intuitive button states\n- **Lap time recording** — up to 10 laps with scrollable history\n- **Real-time display** — updates at ~30 fps using `lv_timer`\n- **Dark-themed UI** — clean design with color-coded buttons\n- **Pure C implementation** — lightweight, no external dependencies beyond LVGL and libuv\n\n## File Structure\n\n```\nstopwatch/\n├── CMakeLists.txt       # CMake build configuration\n├── Kconfig              # NuttX Kconfig options\n├── Make.defs            # NuttX build system integration\n├── Makefile             # NuttX Makefile\n├── README.md            # English documentation\n├── README_zh-cn.md      # Chinese documentation\n├── stopwatch_main.c     # Application entry point\n├── stopwatch_ui.c       # UI creation and event handling\n└── stopwatch_ui.h       # UI header file\n```\n\n## Build\n\nEnable in NuttX config:\n```\nCONFIG_LVX_USE_DEMO_STOPWATCH=y\n```\n\n## Usage\n\n```shell\nnsh> stopwatch\n```\n\n## Checklist\n\n- [x] Follows existing demo structure conventions (Kconfig, Makefile, CMakeLists.txt, Make.defs)\n- [x] Apache License 2.0 headers in all source files\n- [x] Bilingual documentation (English + Chinese)\n- [x] Clean resource management (proper init/deinit)