### PR TITLE
feat: add mini_memo LVGL demo app

### DIFF
--- a/mini_memo/CMakeLists.txt
+++ b/mini_memo/CMakeLists.txt
@@ -1,0 +1,32 @@
+# ##############################################################################
+# packages/demos/mini_memo/CMakeLists.txt
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy of the
+# License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+#
+# ##############################################################################
+
+if(CONFIG_LVX_USE_DEMO_MINI_MEMO)
+  set(PROGNAME mini_memo)
+  set(PRIORITY 100)
+  set(STACKSIZE 40960)
+  set(MODULE ${CONFIG_LVX_USE_DEMO_MINI_MEMO})
+  set(MAINSRC mini_memo_main.c)
+  set(CSRCS mini_memo_core.c mini_memo_ui.c)
+
+  nuttx_add_application(
+    NAME ${PROGNAME}
+    PRIORITY ${PRIORITY}
+    STACKSIZE ${STACKSIZE}
+    MODULE ${MODULE}
+    SRCS ${MAINSRC} ${CSRCS}
+  )
+endif()

--- a/mini_memo/Kconfig
+++ b/mini_memo/Kconfig
@@ -1,0 +1,28 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#
+
+config LVX_USE_DEMO_MINI_MEMO
+	bool "Mini Memo - AI Memory Assistant"
+	default n
+	depends on GRAPHICS_LVGL
+	depends on LV_USE_NUTTX
+	depends on EXAMPLES_AI_AGENT_VELA || VELACLAW_DAEMON
+	select NETUTILS_CJSON
+	---help---
+		AI-powered memory assistant with voice input,
+		intent classification, and proactive reminders.
+		Requires VelaClaw framework for LLM and tools.
+
+if LVX_USE_DEMO_MINI_MEMO
+
+config MINI_MEMO_DATA_DIR
+	string "Mini Memo data directory"
+	default "/data/mini_memo"
+
+config MINI_MEMO_REVIEW_INTERVAL
+	int "Default periodic review interval (seconds)"
+	default 14400
+
+endif

--- a/mini_memo/Make.defs
+++ b/mini_memo/Make.defs
@@ -1,0 +1,18 @@
+#
+# Copyright (C) 2026 Xiaomi Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+ifneq ($(CONFIG_LVX_USE_DEMO_MINI_MEMO),)
+CONFIGURED_APPS += $(APPDIR)/packages/demos/mini_memo
+endif

--- a/mini_memo/Makefile
+++ b/mini_memo/Makefile
@@ -1,0 +1,33 @@
+#
+# Copyright (C) 2026 Xiaomi Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include $(APPDIR)/Make.defs
+
+ifeq ($(CONFIG_LVX_USE_DEMO_MINI_MEMO), y)
+PROGNAME  = mini_memo
+PRIORITY  = 100
+STACKSIZE = 40960
+MODULE    = $(CONFIG_LVX_USE_DEMO_MINI_MEMO)
+
+# AI Agent client SDK include path
+CFLAGS += ${INCDIR_PREFIX}$(APPDIR)/packages/ai_agent/include
+CFLAGS += ${INCDIR_PREFIX}$(APPDIR)/packages/ai_agent/src
+
+CSRCS   = mini_memo_core.c mini_memo_ui.c
+MAINSRC = mini_memo_main.c
+endif
+
+include $(APPDIR)/Application.mk

--- a/mini_memo/mini_memo_core.c
+++ b/mini_memo/mini_memo_core.c
@@ -1,0 +1,1184 @@
+/****************************************************************************
+ * Copyright (C) 2026 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <syslog.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <netutils/cJSON.h>
+
+#include "mini_memo_core.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define MEMO_TAG "mini_memo"
+#define MEMO_MAX_ITEMS 100
+#define MEMO_FILENAME "memos.json"
+#define MEMO_TMP_FILENAME "memos.json.tmp"
+#define MEMO_PATH_MAX 256
+#define MEMO_JSON_VERSION 1
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+typedef struct {
+    memo_item_t items[MEMO_MAX_ITEMS];
+    int count;
+    uint32_t next_id;
+    char data_dir[MEMO_PATH_MAX];
+    char file_path[MEMO_PATH_MAX];
+    char tmp_path[MEMO_PATH_MAX];
+    pthread_mutex_t lock;
+    bool initialized;
+    bool dirty;
+} memo_store_t;
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static memo_store_t g_store;
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static int ensure_directory(const char* path)
+{
+    struct stat st;
+
+    if (stat(path, &st) == 0) {
+        if (S_ISDIR(st.st_mode)) {
+            return 0;
+        }
+        syslog(LOG_WARNING, "%s: path exists but is not a directory: %s\n",
+            MEMO_TAG, path);
+        return -ENOTDIR;
+    }
+
+    if (mkdir(path, 0755) != 0) {
+        int err = errno;
+        syslog(LOG_WARNING, "%s: failed to create directory %s: %d\n",
+            MEMO_TAG, path, err);
+        return -err;
+    }
+
+    syslog(LOG_INFO, "%s: created data directory: %s\n", MEMO_TAG, path);
+    return 0;
+}
+
+static int read_file_contents(const char* path, char** out_buf,
+    size_t* out_len)
+{
+    struct stat st;
+    int fd;
+    ssize_t nread;
+    char* buf;
+
+    if (stat(path, &st) != 0) {
+        return -errno;
+    }
+
+    if (st.st_size == 0 || st.st_size > (1024 * 1024)) {
+        return -EINVAL;
+    }
+
+    buf = malloc(st.st_size + 1);
+    if (!buf) {
+        return -ENOMEM;
+    }
+
+    fd = open(path, O_RDONLY);
+    if (fd < 0) {
+        free(buf);
+        buf = NULL;
+        return -errno;
+    }
+
+    nread = read(fd, buf, st.st_size);
+    close(fd);
+
+    if (nread != st.st_size) {
+        free(buf);
+        buf = NULL;
+        return -EIO;
+    }
+
+    buf[st.st_size] = '\0';
+    *out_buf = buf;
+    *out_len = st.st_size;
+    return 0;
+}
+
+static int find_item_index(uint32_t id)
+{
+    int i;
+
+    for (i = 0; i < g_store.count; i++) {
+        if (g_store.items[i].id == id) {
+            return i;
+        }
+    }
+
+    return -1;
+}
+
+static void remove_item_at(int index)
+{
+    if (index < 0 || index >= g_store.count) {
+        return;
+    }
+
+    if (index < g_store.count - 1) {
+        memmove(&g_store.items[index], &g_store.items[index + 1],
+            (g_store.count - index - 1) * sizeof(memo_item_t));
+    }
+
+    g_store.count--;
+}
+
+static void evict_one_item(void)
+{
+    int oldest_read_idx = -1;
+    int64_t oldest_read_ts = INT64_MAX;
+    int oldest_idx = 0;
+    int64_t oldest_ts = INT64_MAX;
+    int i;
+
+    for (i = 0; i < g_store.count; i++) {
+        if (g_store.items[i].timestamp < oldest_ts) {
+            oldest_ts = g_store.items[i].timestamp;
+            oldest_idx = i;
+        }
+
+        if (g_store.items[i].is_read && g_store.items[i].timestamp < oldest_read_ts) {
+            oldest_read_ts = g_store.items[i].timestamp;
+            oldest_read_idx = i;
+        }
+    }
+
+    if (oldest_read_idx >= 0) {
+        remove_item_at(oldest_read_idx);
+    } else {
+        remove_item_at(oldest_idx);
+    }
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int memo_store_init(const char* data_dir)
+{
+    int ret;
+    int n;
+
+    if (g_store.initialized) {
+        syslog(LOG_WARNING, "%s: store already initialized\n", MEMO_TAG);
+        return 0;
+    }
+
+    memset(&g_store, 0, sizeof(g_store));
+
+    /* Store data directory path */
+
+    strncpy(g_store.data_dir, data_dir, sizeof(g_store.data_dir) - 1);
+    g_store.data_dir[sizeof(g_store.data_dir) - 1] = '\0';
+
+    /* Construct file paths */
+
+    n = snprintf(g_store.file_path, sizeof(g_store.file_path),
+        "%s/%s", data_dir, MEMO_FILENAME);
+    if (n < 0 || (size_t)n >= sizeof(g_store.file_path)) {
+        syslog(LOG_ERR, "%s: file path too long\n", MEMO_TAG);
+        return -ENAMETOOLONG;
+    }
+
+    n = snprintf(g_store.tmp_path, sizeof(g_store.tmp_path),
+        "%s/%s", data_dir, MEMO_TMP_FILENAME);
+    if (n < 0 || (size_t)n >= sizeof(g_store.tmp_path)) {
+        syslog(LOG_ERR, "%s: tmp path too long\n", MEMO_TAG);
+        return -ENAMETOOLONG;
+    }
+
+    /* Ensure data directory exists */
+
+    ret = ensure_directory(data_dir);
+    if (ret != 0) {
+        syslog(LOG_ERR, "%s: cannot ensure data dir: %d\n", MEMO_TAG, ret);
+        return ret;
+    }
+
+    /* Initialize mutex */
+
+    ret = pthread_mutex_init(&g_store.lock, NULL);
+    if (ret != 0) {
+        syslog(LOG_ERR, "%s: mutex init failed: %d\n", MEMO_TAG, ret);
+        return -ret;
+    }
+
+    /* Initialize store state */
+
+    g_store.count = 0;
+    g_store.next_id = 1;
+    g_store.initialized = true;
+
+    /* Load existing data */
+
+    ret = memo_store_load();
+    if (ret != 0) {
+        syslog(LOG_WARNING, "%s: load returned %d, starting empty\n",
+            MEMO_TAG, ret);
+    }
+
+    syslog(LOG_INFO, "%s: initialized, %d items loaded\n",
+        MEMO_TAG, g_store.count);
+    return 0;
+}
+
+void memo_store_deinit(void)
+{
+    if (!g_store.initialized) {
+        return;
+    }
+
+    /* Flush pending changes */
+
+    memo_store_save();
+
+    pthread_mutex_destroy(&g_store.lock);
+    g_store.initialized = false;
+
+    syslog(LOG_INFO, "%s: deinitialized\n", MEMO_TAG);
+}
+
+int memo_store_load(void)
+{
+    char* buf = NULL;
+    size_t buf_len = 0;
+    cJSON* root = NULL;
+    cJSON* version_obj = NULL;
+    cJSON* next_id_obj = NULL;
+    cJSON* items_arr = NULL;
+    cJSON* item_obj = NULL;
+    cJSON* field = NULL;
+    int ret;
+    int i;
+    int arr_size;
+
+    if (!g_store.initialized) {
+        return -EINVAL;
+    }
+
+    ret = read_file_contents(g_store.file_path, &buf, &buf_len);
+    if (ret != 0) {
+        /* File doesn't exist or can't be read - start empty */
+        syslog(LOG_INFO, "%s: no data file, starting empty\n", MEMO_TAG);
+        return 0;
+    }
+
+    root = cJSON_Parse(buf);
+    free(buf);
+    buf = NULL;
+
+    if (!root) {
+        syslog(LOG_WARNING, "%s: JSON parse failed, starting empty\n",
+            MEMO_TAG);
+        return 0;
+    }
+
+    /* Validate version */
+
+    version_obj = cJSON_GetObjectItem(root, "version");
+    if (!version_obj || !cJSON_IsNumber(version_obj)) {
+        syslog(LOG_WARNING, "%s: missing version field\n", MEMO_TAG);
+        cJSON_Delete(root);
+        root = NULL;
+        return 0;
+    }
+
+    if (version_obj->valueint != MEMO_JSON_VERSION) {
+        syslog(LOG_WARNING, "%s: unsupported version %d\n",
+            MEMO_TAG, version_obj->valueint);
+        cJSON_Delete(root);
+        root = NULL;
+        return 0;
+    }
+
+    /* Read next_id */
+
+    next_id_obj = cJSON_GetObjectItem(root, "next_id");
+    if (next_id_obj && cJSON_IsNumber(next_id_obj)) {
+        g_store.next_id = (uint32_t)next_id_obj->valuedouble;
+    }
+
+    /* Read items array */
+
+    items_arr = cJSON_GetObjectItem(root, "items");
+    if (!items_arr || !cJSON_IsArray(items_arr)) {
+        syslog(LOG_WARNING, "%s: missing items array\n", MEMO_TAG);
+        cJSON_Delete(root);
+        root = NULL;
+        return 0;
+    }
+
+    arr_size = cJSON_GetArraySize(items_arr);
+    if (arr_size > MEMO_MAX_ITEMS) {
+        arr_size = MEMO_MAX_ITEMS;
+    }
+
+    pthread_mutex_lock(&g_store.lock);
+    g_store.count = 0;
+
+    for (i = 0; i < arr_size; i++) {
+        item_obj = cJSON_GetArrayItem(items_arr, i);
+        if (!item_obj || !cJSON_IsObject(item_obj)) {
+            continue;
+        }
+
+        memo_item_t* item = &g_store.items[g_store.count];
+        memset(item, 0, sizeof(memo_item_t));
+
+        field = cJSON_GetObjectItem(item_obj, "id");
+        if (field && cJSON_IsNumber(field)) {
+            item->id = (uint32_t)field->valuedouble;
+        }
+
+        field = cJSON_GetObjectItem(item_obj, "type");
+        if (field && cJSON_IsNumber(field)) {
+            item->type = (memo_type_t)field->valueint;
+        }
+
+        field = cJSON_GetObjectItem(item_obj, "content");
+        if (field && cJSON_IsString(field) && field->valuestring) {
+            strncpy(item->content, field->valuestring,
+                sizeof(item->content) - 1);
+            item->content[sizeof(item->content) - 1] = '\0';
+        }
+
+        field = cJSON_GetObjectItem(item_obj, "timestamp");
+        if (field && cJSON_IsNumber(field)) {
+            item->timestamp = (int64_t)field->valuedouble;
+        }
+
+        field = cJSON_GetObjectItem(item_obj, "remind_at");
+        if (field && cJSON_IsNumber(field)) {
+            item->remind_at = (int64_t)field->valuedouble;
+        }
+
+        field = cJSON_GetObjectItem(item_obj, "is_read");
+        if (field) {
+            item->is_read = cJSON_IsTrue(field) ? true : false;
+        }
+
+        g_store.count++;
+    }
+
+    pthread_mutex_unlock(&g_store.lock);
+
+    cJSON_Delete(root);
+    root = NULL;
+
+    syslog(LOG_INFO, "%s: loaded %d items from disk\n",
+        MEMO_TAG, g_store.count);
+    return 0;
+}
+
+int memo_store_save(void)
+{
+    cJSON* root = NULL;
+    cJSON* items_arr = NULL;
+    cJSON* item_obj = NULL;
+    char* json_str = NULL;
+    int fd;
+    ssize_t written;
+    size_t json_len;
+    int ret = 0;
+    int i;
+
+    if (!g_store.initialized) {
+        return -EINVAL;
+    }
+
+    root = cJSON_CreateObject();
+    if (!root) {
+        syslog(LOG_ERR, "%s: failed to create JSON object\n", MEMO_TAG);
+        return -ENOMEM;
+    }
+
+    if (!cJSON_AddNumberToObject(root, "version", MEMO_JSON_VERSION)) {
+        cJSON_Delete(root);
+        root = NULL;
+        return -ENOMEM;
+    }
+
+    pthread_mutex_lock(&g_store.lock);
+
+    if (!cJSON_AddNumberToObject(root, "next_id",
+            (double)g_store.next_id)) {
+        pthread_mutex_unlock(&g_store.lock);
+        cJSON_Delete(root);
+        root = NULL;
+        return -ENOMEM;
+    }
+
+    items_arr = cJSON_AddArrayToObject(root, "items");
+    if (!items_arr) {
+        pthread_mutex_unlock(&g_store.lock);
+        cJSON_Delete(root);
+        root = NULL;
+        return -ENOMEM;
+    }
+
+    for (i = 0; i < g_store.count; i++) {
+        item_obj = cJSON_CreateObject();
+        if (!item_obj) {
+            pthread_mutex_unlock(&g_store.lock);
+            cJSON_Delete(root);
+            root = NULL;
+            return -ENOMEM;
+        }
+
+        cJSON_AddNumberToObject(item_obj, "id",
+            (double)g_store.items[i].id);
+        cJSON_AddNumberToObject(item_obj, "type",
+            (double)g_store.items[i].type);
+        cJSON_AddStringToObject(item_obj, "content",
+            g_store.items[i].content);
+        cJSON_AddNumberToObject(item_obj, "timestamp",
+            (double)g_store.items[i].timestamp);
+        cJSON_AddNumberToObject(item_obj, "remind_at",
+            (double)g_store.items[i].remind_at);
+        cJSON_AddBoolToObject(item_obj, "is_read",
+            g_store.items[i].is_read);
+
+        cJSON_AddItemToArray(items_arr, item_obj);
+    }
+
+    pthread_mutex_unlock(&g_store.lock);
+
+    /* Serialize to string */
+
+    json_str = cJSON_PrintUnformatted(root);
+    cJSON_Delete(root);
+    root = NULL;
+
+    if (!json_str) {
+        syslog(LOG_ERR, "%s: failed to serialize JSON\n", MEMO_TAG);
+        return -ENOMEM;
+    }
+
+    json_len = strlen(json_str);
+
+    /* Atomic write: write to .tmp then rename */
+
+    fd = open(g_store.tmp_path, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (fd < 0) {
+        syslog(LOG_ERR, "%s: failed to open tmp file: %d\n",
+            MEMO_TAG, errno);
+        free(json_str);
+        json_str = NULL;
+        return -errno;
+    }
+
+    written = write(fd, json_str, json_len);
+    close(fd);
+    free(json_str);
+    json_str = NULL;
+
+    if (written < 0 || (size_t)written != json_len) {
+        syslog(LOG_ERR, "%s: write failed\n", MEMO_TAG);
+        unlink(g_store.tmp_path);
+        return -EIO;
+    }
+
+    /* Rename atomically */
+
+    ret = rename(g_store.tmp_path, g_store.file_path);
+    if (ret != 0) {
+        ret = -errno;
+        syslog(LOG_ERR, "%s: rename failed: %d\n", MEMO_TAG, -ret);
+        unlink(g_store.tmp_path);
+        return ret;
+    }
+
+    return 0;
+}
+
+int memo_store_add(const memo_item_t* item)
+{
+    memo_item_t* new_item;
+
+    if (!g_store.initialized || !item) {
+        return -EINVAL;
+    }
+
+    pthread_mutex_lock(&g_store.lock);
+
+    /* Enforce capacity: evict if full */
+
+    if (g_store.count >= MEMO_MAX_ITEMS) {
+        evict_one_item();
+    }
+
+    /* Add new item */
+
+    new_item = &g_store.items[g_store.count];
+    memcpy(new_item, item, sizeof(memo_item_t));
+    new_item->id = g_store.next_id++;
+
+    /* Ensure content is null-terminated */
+
+    new_item->content[sizeof(new_item->content) - 1] = '\0';
+
+    g_store.count++;
+
+    pthread_mutex_unlock(&g_store.lock);
+
+    /* Mark dirty - will be flushed by periodic timer */
+
+    g_store.dirty = true;
+
+    return (int)new_item->id;
+}
+
+int memo_store_delete(uint32_t id)
+{
+    int index;
+
+    if (!g_store.initialized) {
+        return -EINVAL;
+    }
+
+    pthread_mutex_lock(&g_store.lock);
+
+    index = find_item_index(id);
+    if (index < 0) {
+        pthread_mutex_unlock(&g_store.lock);
+        return -ENOENT;
+    }
+
+    remove_item_at(index);
+
+    pthread_mutex_unlock(&g_store.lock);
+
+    g_store.dirty = true;
+    return 0;
+}
+
+int memo_store_mark_read(uint32_t id)
+{
+    int index;
+
+    if (!g_store.initialized) {
+        return -EINVAL;
+    }
+
+    pthread_mutex_lock(&g_store.lock);
+
+    index = find_item_index(id);
+    if (index < 0) {
+        pthread_mutex_unlock(&g_store.lock);
+        return -ENOENT;
+    }
+
+    g_store.items[index].is_read = true;
+
+    pthread_mutex_unlock(&g_store.lock);
+
+    g_store.dirty = true;
+    return 0;
+}
+
+int memo_store_get_count(memo_type_t type, bool unread_only)
+{
+    int count = 0;
+    int i;
+
+    if (!g_store.initialized) {
+        return 0;
+    }
+
+    pthread_mutex_lock(&g_store.lock);
+
+    for (i = 0; i < g_store.count; i++) {
+        if (g_store.items[i].type != type) {
+            continue;
+        }
+
+        if (unread_only && g_store.items[i].is_read) {
+            continue;
+        }
+
+        count++;
+    }
+
+    pthread_mutex_unlock(&g_store.lock);
+
+    return count;
+}
+
+int memo_store_get_all(memo_item_t* out, int max_items)
+{
+    int copy_count;
+
+    if (!g_store.initialized || !out || max_items <= 0) {
+        return 0;
+    }
+
+    pthread_mutex_lock(&g_store.lock);
+    copy_count = g_store.count < max_items ? g_store.count : max_items;
+    memcpy(out, g_store.items, copy_count * sizeof(memo_item_t));
+    pthread_mutex_unlock(&g_store.lock);
+
+    return copy_count;
+}
+
+int memo_store_get_recent(memo_item_t* out, int max_items)
+{
+    int start;
+    int copy_count;
+
+    if (!g_store.initialized || !out || max_items <= 0) {
+        return 0;
+    }
+
+    pthread_mutex_lock(&g_store.lock);
+    copy_count = g_store.count < max_items ? g_store.count : max_items;
+    start = g_store.count - copy_count;
+    memcpy(out, &g_store.items[start], copy_count * sizeof(memo_item_t));
+    pthread_mutex_unlock(&g_store.lock);
+
+    return copy_count;
+}
+
+int memo_store_get_due_reminders(int64_t now, memo_item_t* out, int max_out)
+{
+    int n = 0;
+    int i;
+
+    if (!g_store.initialized || !out || max_out <= 0) {
+        return 0;
+    }
+
+    pthread_mutex_lock(&g_store.lock);
+    for (i = 0; i < g_store.count && n < max_out; i++) {
+        if (g_store.items[i].remind_at > 0 && g_store.items[i].remind_at <= now && !g_store.items[i].is_read) {
+            out[n++] = g_store.items[i];
+        }
+    }
+    pthread_mutex_unlock(&g_store.lock);
+
+    return n;
+}
+
+void memo_store_clear_all(void)
+{
+    if (!g_store.initialized) {
+        return;
+    }
+
+    pthread_mutex_lock(&g_store.lock);
+    g_store.count = 0;
+    pthread_mutex_unlock(&g_store.lock);
+
+    g_store.dirty = true;
+
+    syslog(LOG_INFO, "%s: all items cleared\n", MEMO_TAG);
+}
+
+void memo_store_flush(void)
+{
+    if (!g_store.initialized || !g_store.dirty) {
+        return;
+    }
+
+    g_store.dirty = false;
+    memo_store_save();
+}
+
+/****************************************************************************
+ * memo_classify_local - Offline keyword-based intent classification
+ *
+ * This function provides a local fallback for intent classification when
+ * the VelaClaw LLM service is unavailable. It uses simple substring
+ * matching to classify text into memo types.
+ *
+ * Input:
+ *   text - UTF-8 text to classify (may be NULL)
+ *
+ * Returns:
+ *   MEMO_TYPE_TODO     - if todo keywords found
+ *   MEMO_TYPE_SCHEDULE - if schedule keywords found
+ *   MEMO_TYPE_MEMO     - default (no keyword match or NULL input)
+ ****************************************************************************/
+
+memo_type_t memo_classify_local(const char* text)
+{
+    /* Handle NULL input gracefully */
+
+    if (!text) {
+        syslog(LOG_INFO, "%s: classify_local: NULL input, default MEMO\n",
+            MEMO_TAG);
+        return MEMO_TYPE_MEMO;
+    }
+
+    /* Check for TODO keywords */
+
+    if (strstr(text, "\xe6\x8f\x90\xe9\x86\x92\xe6\x88\x91") != NULL || /* ti xing wo (remind me) */
+        strstr(text, "\xe5\x88\xab\xe5\xbf\x98\xe4\xba\x86") != NULL || /* bie wang le (do not forget) */
+        strstr(text, "\xe5\xbe\x85\xe5\x8a\x9e") != NULL || /* dai ban (todo) */
+        strstr(text, "todo") != NULL) {
+        syslog(LOG_INFO, "%s: classify_local: matched TODO\n", MEMO_TAG);
+        return MEMO_TYPE_TODO;
+    }
+
+    /* Check for SCHEDULE keywords */
+
+    if (strstr(text, "\xe5\xae\x89\xe6\x8e\x92") != NULL || /* an pai (arrange) */
+        strstr(text, "\xe7\xba\xa6\xe4\xba\x86") != NULL || /* yue le (appointment) */
+        strstr(text, "\xe5\x87\xa0\xe7\x82\xb9") != NULL || /* ji dian (what time) */
+        strstr(text, "\xe6\x97\xa5\xe7\xa8\x8b") != NULL || /* ri cheng (schedule) */
+        strstr(text, "schedule") != NULL) {
+        syslog(LOG_INFO, "%s: classify_local: matched SCHEDULE\n",
+            MEMO_TAG);
+        return MEMO_TYPE_SCHEDULE;
+    }
+
+    /* Default: MEMO */
+
+    syslog(LOG_INFO, "%s: classify_local: no keyword match, default MEMO\n",
+        MEMO_TAG);
+    return MEMO_TYPE_MEMO;
+}
+
+/****************************************************************************
+ * Voice + AI Agent Integration
+ ****************************************************************************/
+
+#include <velaclaw/client.h>
+
+/* voice_channel is an internal velaclaw module; we link against it
+ * since mini_memo depends on CONFIG_EXAMPLES_AI_AGENT_VELA */
+
+extern int voice_channel_init(void);
+extern int voice_channel_start(void);
+extern int voice_channel_stop_with_text(char* text_out, size_t text_cap);
+extern void voice_channel_cleanup(void);
+
+/****************************************************************************
+ * Private Data - Agent
+ ****************************************************************************/
+
+static velaclaw_client_t* g_client;
+static bool g_agent_connected;
+
+/****************************************************************************
+ * Private Functions - Agent
+ ****************************************************************************/
+
+static int parse_classify_json(const char* json_str,
+    classify_result_t* result)
+{
+    cJSON* root = NULL;
+    cJSON* type_obj = NULL;
+    cJSON* content_obj = NULL;
+    cJSON* remind_obj = NULL;
+    const char* type_str;
+
+    if (!json_str || !result) {
+        return -EINVAL;
+    }
+
+    root = cJSON_Parse(json_str);
+    if (!root) {
+        syslog(LOG_WARNING, "%s: classify JSON parse failed\n", MEMO_TAG);
+        return -EINVAL;
+    }
+
+    type_obj = cJSON_GetObjectItem(root, "type");
+    content_obj = cJSON_GetObjectItem(root, "content");
+    remind_obj = cJSON_GetObjectItem(root, "remind_at");
+
+    if (!type_obj || !cJSON_IsString(type_obj)) {
+        cJSON_Delete(root);
+        return -EINVAL;
+    }
+
+    type_str = type_obj->valuestring;
+    if (strcmp(type_str, "todo") == 0) {
+        result->type = MEMO_TYPE_TODO;
+    } else if (strcmp(type_str, "schedule") == 0) {
+        result->type = MEMO_TYPE_SCHEDULE;
+    } else {
+        result->type = MEMO_TYPE_MEMO;
+    }
+
+    if (content_obj && cJSON_IsString(content_obj)) {
+        strncpy(result->content, content_obj->valuestring,
+            sizeof(result->content) - 1);
+        result->content[sizeof(result->content) - 1] = '\0';
+    } else {
+        result->content[0] = '\0';
+    }
+
+    if (remind_obj && cJSON_IsNumber(remind_obj)) {
+        result->remind_at = (int64_t)remind_obj->valuedouble;
+    } else {
+        result->remind_at = 0;
+    }
+
+    cJSON_Delete(root);
+    return 0;
+}
+
+static const char* g_classify_prompt_fmt = "You are a memo classifier. Given the user's voice input, "
+                                           "classify it and extract structured data.\n\n"
+                                           "Input: \"%s\"\n\n"
+                                           "Respond ONLY with JSON:\n"
+                                           "{\"type\":\"memo|todo|schedule\","
+                                           "\"content\":\"<cleaned content>\","
+                                           "\"remind_at\":<unix_timestamp_or_0>}\n\n"
+                                           "Rules:\n"
+                                           "- \"memo\": general notes\n"
+                                           "- \"todo\": tasks with reminders\n"
+                                           "- \"schedule\": appointments with times\n"
+                                           "- content: concise version of input\n"
+                                           "- remind_at: extract time if mentioned, else 0";
+
+/****************************************************************************
+ * Public Functions - Agent
+ ****************************************************************************/
+
+int memo_agent_init(void)
+{
+    int voice_ret;
+
+    syslog(LOG_INFO, "%s: agent init\n", MEMO_TAG);
+
+    /* Voice is local to this process and should remain usable even if the
+     * optional VelaClaw client cannot connect. */
+
+    voice_ret = voice_channel_init();
+    if (voice_ret < 0) {
+        syslog(LOG_WARNING, "%s: voice_channel_init failed: %d\n",
+            MEMO_TAG, voice_ret);
+    }
+
+    /* Open VelaClaw client for remote LLM classification. This is optional:
+     * the app already falls back to local classification when disconnected. */
+
+    g_client = velaclaw_client_open("mini_memo");
+    if (!g_client) {
+        syslog(LOG_WARNING, "%s: velaclaw_client_open failed\n", MEMO_TAG);
+        g_agent_connected = false;
+        return voice_ret;
+    }
+
+    g_agent_connected = true;
+    syslog(LOG_INFO, "%s: agent connected\n", MEMO_TAG);
+    return voice_ret;
+}
+
+void memo_agent_deinit(void)
+{
+    syslog(LOG_INFO, "%s: agent deinit\n", MEMO_TAG);
+
+    voice_channel_cleanup();
+
+    if (g_client) {
+        velaclaw_client_close(g_client);
+        g_client = NULL;
+    }
+
+    g_agent_connected = false;
+}
+
+bool memo_agent_is_connected(void)
+{
+    return g_agent_connected;
+}
+
+int memo_voice_start(void)
+{
+    int ret;
+
+    syslog(LOG_INFO, "%s: voice_start\n", MEMO_TAG);
+    ret = voice_channel_start();
+    if (ret < 0) {
+        syslog(LOG_ERR, "%s: voice_channel_start failed: %d\n",
+            MEMO_TAG, ret);
+    }
+
+    return ret;
+}
+
+int memo_voice_stop(char* text_out, size_t text_cap)
+{
+    int ret;
+
+    if (!text_out || text_cap == 0) {
+        return -EINVAL;
+    }
+
+    syslog(LOG_INFO, "%s: voice_stop\n", MEMO_TAG);
+    ret = voice_channel_stop_with_text(text_out, text_cap);
+    if (ret < 0) {
+        syslog(LOG_ERR, "%s: voice_channel_stop_with_text failed: %d\n",
+            MEMO_TAG, ret);
+        text_out[0] = '\0';
+    } else {
+        syslog(LOG_INFO, "%s: ASR result: \"%s\"\n", MEMO_TAG, text_out);
+    }
+
+    return ret;
+}
+
+/* Callback context for async classification */
+
+typedef struct {
+    memo_classify_cb user_cb;
+    void* user_cookie;
+    char input_text[200];
+} classify_ctx_t;
+
+static void classify_response_cb(int status, const char* response_json,
+    void* cookie)
+{
+    classify_ctx_t* ctx = (classify_ctx_t*)cookie;
+    classify_result_t result;
+    int ret;
+
+    memset(&result, 0, sizeof(result));
+
+    if (status != 0 || !response_json) {
+        /* LLM failed, fall back to local classification */
+
+        syslog(LOG_WARNING, "%s: LLM classify failed (status=%d), "
+                            "using local\n",
+            MEMO_TAG, status);
+        result.type = memo_classify_local(ctx->input_text);
+        strncpy(result.content, ctx->input_text,
+            sizeof(result.content) - 1);
+        result.content[sizeof(result.content) - 1] = '\0';
+        result.remind_at = 0;
+    } else {
+        ret = parse_classify_json(response_json, &result);
+        if (ret < 0) {
+            /* Parse failed, fall back to local */
+
+            syslog(LOG_WARNING, "%s: classify JSON parse failed, "
+                                "using local\n",
+                MEMO_TAG);
+            result.type = memo_classify_local(ctx->input_text);
+            strncpy(result.content, ctx->input_text,
+                sizeof(result.content) - 1);
+            result.content[sizeof(result.content) - 1] = '\0';
+            result.remind_at = 0;
+        }
+    }
+
+    if (ctx->user_cb) {
+        ctx->user_cb(0, &result, ctx->user_cookie);
+    }
+
+    free(ctx);
+}
+
+int memo_classify_async(const char* text, memo_classify_cb cb, void* cookie)
+{
+    classify_ctx_t* ctx = NULL;
+    velaclaw_ask_req_t req;
+    char* prompt = NULL;
+    int prompt_len;
+    int ret;
+
+    if (!text || !cb) {
+        return -EINVAL;
+    }
+
+    /* If agent not connected, do local classification immediately */
+
+    if (!g_agent_connected || !g_client) {
+        classify_result_t result;
+
+        memset(&result, 0, sizeof(result));
+        result.type = memo_classify_local(text);
+        strncpy(result.content, text, sizeof(result.content) - 1);
+        result.content[sizeof(result.content) - 1] = '\0';
+        result.remind_at = 0;
+        cb(0, &result, cookie);
+        return 0;
+    }
+
+    /* Build prompt */
+
+    prompt_len = strlen(g_classify_prompt_fmt) + strlen(text) + 16;
+    prompt = malloc(prompt_len);
+    if (!prompt) {
+        return -ENOMEM;
+    }
+
+    snprintf(prompt, prompt_len, g_classify_prompt_fmt, text);
+
+    /* Allocate callback context */
+
+    ctx = malloc(sizeof(classify_ctx_t));
+    if (!ctx) {
+        free(prompt);
+        return -ENOMEM;
+    }
+
+    ctx->user_cb = cb;
+    ctx->user_cookie = cookie;
+    strncpy(ctx->input_text, text, sizeof(ctx->input_text) - 1);
+    ctx->input_text[sizeof(ctx->input_text) - 1] = '\0';
+
+    /* Send to VelaClaw */
+
+    memset(&req, 0, sizeof(req));
+    req.text = prompt;
+    req.timeout_ms = 15000;
+
+    ret = velaclaw_ask(g_client, &req, classify_response_cb, ctx);
+    free(prompt);
+    prompt = NULL;
+
+    if (ret < 0) {
+        syslog(LOG_ERR, "%s: velaclaw_ask failed: %d\n", MEMO_TAG, ret);
+        free(ctx);
+        ctx = NULL;
+
+        /* Fall back to local */
+
+        classify_result_t result;
+
+        memset(&result, 0, sizeof(result));
+        result.type = memo_classify_local(text);
+        strncpy(result.content, text, sizeof(result.content) - 1);
+        result.content[sizeof(result.content) - 1] = '\0';
+        result.remind_at = 0;
+        cb(0, &result, cookie);
+        return 0;
+    }
+
+    return 0;
+}
+
+/* Sync wrapper context */
+
+typedef struct {
+    pthread_mutex_t mtx;
+    pthread_cond_t cond;
+    bool done;
+    int status;
+    classify_result_t result;
+} sync_classify_ctx_t;
+
+static void sync_classify_cb(int status,
+    const classify_result_t* result, void* cookie)
+{
+    sync_classify_ctx_t* ctx = (sync_classify_ctx_t*)cookie;
+
+    pthread_mutex_lock(&ctx->mtx);
+    ctx->status = status;
+    if (status == 0 && result) {
+        ctx->result = *result;
+    }
+    ctx->done = true;
+    pthread_cond_signal(&ctx->cond);
+    pthread_mutex_unlock(&ctx->mtx);
+}
+
+int memo_classify_sync(const char* text, classify_result_t* result)
+{
+    sync_classify_ctx_t ctx;
+    struct timespec ts;
+    int ret;
+
+    if (!text || !result) {
+        return -EINVAL;
+    }
+
+    memset(result, 0, sizeof(*result));
+
+    /* If agent not connected, use local directly */
+
+    if (!g_agent_connected || !g_client) {
+        result->type = memo_classify_local(text);
+        strncpy(result->content, text, sizeof(result->content) - 1);
+        result->content[sizeof(result->content) - 1] = '\0';
+        result->remind_at = 0;
+        return 0;
+    }
+
+    /* Use async path with sync wait */
+
+    pthread_mutex_init(&ctx.mtx, NULL);
+    pthread_cond_init(&ctx.cond, NULL);
+    ctx.done = false;
+    ctx.status = -1;
+    memset(&ctx.result, 0, sizeof(ctx.result));
+
+    ret = memo_classify_async(text, sync_classify_cb, &ctx);
+    if (ret < 0) {
+        pthread_mutex_destroy(&ctx.mtx);
+        pthread_cond_destroy(&ctx.cond);
+        return ret;
+    }
+
+    /* Wait up to 20 seconds */
+
+    pthread_mutex_lock(&ctx.mtx);
+    if (!ctx.done) {
+        clock_gettime(CLOCK_REALTIME, &ts);
+        ts.tv_sec += 20;
+        pthread_cond_timedwait(&ctx.cond, &ctx.mtx, &ts);
+    }
+    pthread_mutex_unlock(&ctx.mtx);
+
+    if (ctx.done && ctx.status == 0) {
+        *result = ctx.result;
+    } else {
+        /* Timeout or error - fallback to local */
+
+        result->type = memo_classify_local(text);
+        strncpy(result->content, text, sizeof(result->content) - 1);
+        result->content[sizeof(result->content) - 1] = '\0';
+        result->remind_at = 0;
+    }
+
+    pthread_mutex_destroy(&ctx.mtx);
+    pthread_cond_destroy(&ctx.cond);
+    return 0;
+}

--- a/mini_memo/mini_memo_core.h
+++ b/mini_memo/mini_memo_core.h
@@ -1,0 +1,112 @@
+/****************************************************************************
+ * Copyright (C) 2026 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ****************************************************************************/
+
+#ifndef __MINI_MEMO_CORE_H
+#define __MINI_MEMO_CORE_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+typedef enum {
+    MEMO_TYPE_MEMO = 0,
+    MEMO_TYPE_TODO = 1,
+    MEMO_TYPE_SCHEDULE = 2,
+} memo_type_t;
+
+typedef struct {
+    uint32_t id;
+    memo_type_t type;
+    char content[200];
+    int64_t timestamp;
+    int64_t remind_at;
+    bool is_read;
+} memo_item_t;
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+int memo_store_init(const char* data_dir);
+void memo_store_deinit(void);
+int memo_store_load(void);
+int memo_store_save(void);
+void memo_store_flush(void);
+int memo_store_add(const memo_item_t* item);
+int memo_store_delete(uint32_t id);
+int memo_store_mark_read(uint32_t id);
+int memo_store_get_count(memo_type_t type, bool unread_only);
+int memo_store_get_all(memo_item_t* out, int max_items);
+int memo_store_get_recent(memo_item_t* out, int max_items);
+int memo_store_get_due_reminders(int64_t now, memo_item_t* out, int max_out);
+void memo_store_clear_all(void);
+
+/* -- Local Intent Classification ---------------------- */
+
+memo_type_t memo_classify_local(const char* text);
+
+/* -- Voice + AI Integration --------------------------- */
+
+typedef struct {
+    memo_type_t type;
+    char content[200];
+    int64_t remind_at;
+} classify_result_t;
+
+/**
+ * Initialize VelaClaw client connection.
+ * Must be called before memo_voice_* or memo_ai_classify.
+ */
+int memo_agent_init(void);
+void memo_agent_deinit(void);
+bool memo_agent_is_connected(void);
+
+/**
+ * Start voice recording via voice_channel.
+ * Returns 0 on success, negative errno on failure.
+ */
+int memo_voice_start(void);
+
+/**
+ * Stop recording and get ASR transcription.
+ * text_out: buffer to receive transcribed text.
+ * text_cap: buffer capacity.
+ * Returns 0 on success, negative errno on failure.
+ */
+int memo_voice_stop(char* text_out, size_t text_cap);
+
+/**
+ * Classify text using VelaClaw LLM (async).
+ * Falls back to memo_classify_local if agent unavailable.
+ */
+typedef void (*memo_classify_cb)(int status,
+    const classify_result_t* result, void* cookie);
+int memo_classify_async(const char* text, memo_classify_cb cb, void* cookie);
+
+/**
+ * Classify text synchronously (uses LLM if available, else local).
+ * Returns 0 on success.
+ */
+int memo_classify_sync(const char* text, classify_result_t* result);
+
+#endif /* __MINI_MEMO_CORE_H */

--- a/mini_memo/mini_memo_main.c
+++ b/mini_memo/mini_memo_main.c
@@ -1,0 +1,212 @@
+/****************************************************************************
+ * Copyright (C) 2026 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <syslog.h>
+
+#ifndef CONFIG_LV_USE_NUTTX_LIBUV
+#include <unistd.h>
+#else
+#include <uv.h>
+#endif
+
+#include <lvgl/lvgl.h>
+
+#include "mini_memo_core.h"
+#include "mini_memo_ui.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#ifndef CONFIG_MINI_MEMO_DATA_DIR
+#define CONFIG_MINI_MEMO_DATA_DIR "/data/mini_memo"
+#endif
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_LV_USE_NUTTX_LIBUV
+static void lv_nuttx_uv_loop(uv_loop_t* loop, lv_nuttx_result_t* result)
+{
+    lv_nuttx_uv_t uv_info;
+    void* data;
+
+    uv_loop_init(loop);
+
+    lv_memset(&uv_info, 0, sizeof(uv_info));
+    uv_info.loop = loop;
+    uv_info.disp = result->disp;
+    uv_info.indev = result->indev;
+#ifdef CONFIG_UINPUT_TOUCH
+    uv_info.uindev = result->utouch_indev;
+#endif
+
+    data = lv_nuttx_uv_init(&uv_info);
+    uv_run(loop, UV_RUN_DEFAULT);
+    lv_nuttx_uv_deinit(&data);
+}
+#else
+static void lv_nuttx_loop(void)
+{
+    while (1) {
+        uint32_t idle;
+
+        idle = lv_timer_handler();
+        idle = idle ? idle : 1;
+        usleep(idle * 1000);
+    }
+}
+#endif
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int main(int argc, FAR char* argv[])
+{
+    lv_nuttx_dsc_t info;
+    lv_nuttx_result_t result;
+#ifdef CONFIG_LV_USE_NUTTX_LIBUV
+    uv_loop_t ui_loop;
+#endif
+    char selftest_flag_path[128];
+    bool ptt_selftest = false;
+    int ret;
+    int i;
+
+    syslog(LOG_INFO, "Mini Memo starting\n");
+
+    for (i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--ptt-selftest") == 0 || strcmp(argv[i], "ptt-selftest") == 0 || strcmp(argv[i], "selftest") == 0) {
+            ptt_selftest = true;
+            syslog(LOG_INFO, "Mini Memo: PTT selftest requested via '%s'\n",
+                argv[i]);
+        }
+    }
+
+#ifdef CONFIG_LV_USE_NUTTX_LIBUV
+    lv_memset(&ui_loop, 0, sizeof(uv_loop_t));
+#endif
+
+    if (lv_is_initialized()) {
+        syslog(LOG_ERR, "Mini Memo: LVGL already initialized\n");
+        return -1;
+    }
+
+    lv_init();
+
+    lv_nuttx_dsc_init(&info);
+
+    /* Match luncher_mini initialization exactly */
+
+#ifdef CONFIG_LV_USE_NUTTX_LCD
+    info.fb_path = "/dev/lcd0";
+#endif
+
+    lv_nuttx_init(&info, &result);
+
+    if (result.disp == NULL) {
+        syslog(LOG_ERR, "Mini Memo: display init failed\n");
+        lv_deinit();
+        return -1;
+    }
+
+    ret = memo_store_init(CONFIG_MINI_MEMO_DATA_DIR);
+    if (ret < 0) {
+        syslog(LOG_ERR, "Mini Memo: store init failed: %d\n", ret);
+        lv_nuttx_deinit(&result);
+        lv_deinit();
+        return ret;
+    }
+
+    snprintf(selftest_flag_path, sizeof(selftest_flag_path),
+        "%s/.ptt_selftest", CONFIG_MINI_MEMO_DATA_DIR);
+    if (!ptt_selftest && access(selftest_flag_path, F_OK) == 0) {
+        ptt_selftest = true;
+        syslog(LOG_INFO, "Mini Memo: PTT selftest requested via '%s'\n",
+            selftest_flag_path);
+    }
+
+    /* Initialize AI agent (voice + LLM). Non-fatal if it fails. */
+
+    ret = memo_agent_init();
+    if (ret < 0) {
+        syslog(LOG_WARNING, "Mini Memo: voice init failed: %d\n", ret);
+    }
+
+    ret = memo_ui_init();
+    if (ret < 0) {
+        syslog(LOG_ERR, "Mini Memo: UI init failed: %d\n", ret);
+        memo_store_deinit();
+        lv_nuttx_deinit(&result);
+        lv_deinit();
+        return ret;
+    }
+
+    if (ptt_selftest) {
+        ret = memo_ui_start_ptt_selftest(1500);
+        if (ret < 0) {
+            syslog(LOG_ERR, "Mini Memo: PTT selftest scheduling failed: %d\n", ret);
+        }
+    }
+
+#ifdef CONFIG_LV_USE_NUTTX_LIBUV
+    syslog(LOG_INFO, "Mini Memo: entering libuv event loop\n");
+    lv_nuttx_uv_loop(&ui_loop, &result);
+    syslog(LOG_INFO, "Mini Memo: libuv loop exited\n");
+#else
+    syslog(LOG_INFO, "Mini Memo: entering poll loop, indev=%p disp=%p\n",
+        result.indev, result.disp);
+    syslog(LOG_INFO, "Mini Memo: display res=%ldx%ld\n",
+        (long)lv_display_get_horizontal_resolution(result.disp),
+        (long)lv_display_get_vertical_resolution(result.disp));
+
+    /* Ensure indev is in timer (poll) mode with 30ms period */
+    if (result.indev) {
+        lv_indev_set_mode(result.indev, LV_INDEV_MODE_TIMER);
+        lv_timer_t* t = lv_indev_get_read_timer(result.indev);
+        if (t) {
+            lv_timer_set_period(t, 30);
+            syslog(LOG_INFO, "Mini Memo: indev timer set to 30ms\n");
+        } else {
+            syslog(LOG_ERR, "Mini Memo: indev has no timer!\n");
+        }
+    } else {
+        syslog(LOG_ERR, "Mini Memo: indev is NULL!\n");
+    }
+
+    lv_nuttx_loop();
+#endif
+
+    memo_ui_deinit();
+    memo_agent_deinit();
+    memo_store_deinit();
+    lv_nuttx_deinit(&result);
+    lv_deinit();
+
+    syslog(LOG_INFO, "Mini Memo exiting\n");
+    return 0;
+}

--- a/mini_memo/mini_memo_ui.c
+++ b/mini_memo/mini_memo_ui.c
@@ -1,0 +1,855 @@
+/****************************************************************************
+ * Copyright (C) 2026 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <errno.h>
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <syslog.h>
+#include <time.h>
+
+#include <lvgl/lvgl.h>
+
+#include "mini_memo_core.h"
+#include "mini_memo_ui.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define UI_BG_COLOR 0x121220
+#define UI_ACCENT_COLOR 0x3a7bd5
+#define UI_TEXT_MUTED 0x888899
+#define UI_CARD_BG 0x1e1e30
+#define MEMO_MAX_DISPLAY 20
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static int g_screen_w = 320;
+static int g_screen_h = 240;
+
+static lv_obj_t* g_tileview;
+static lv_obj_t* g_tiles[4]; /* Home, Voice, Review, Settings */
+static lv_obj_t* g_nav_dots[4];
+static lv_obj_t* g_nav_bar;
+static lv_obj_t* g_home_memo_count;
+static lv_obj_t* g_home_todo_count;
+static lv_obj_t* g_home_sched_count;
+static lv_timer_t* g_flush_timer;
+static lv_timer_t* g_remind_timer;
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static const lv_font_t* get_font_large(void)
+{
+#if LV_FONT_MONTSERRAT_30
+    return &lv_font_montserrat_30;
+#else
+    return LV_FONT_DEFAULT;
+#endif
+}
+
+static const lv_font_t* get_font_medium(void)
+{
+#if LV_FONT_MONTSERRAT_20
+    return &lv_font_montserrat_20;
+#else
+    return LV_FONT_DEFAULT;
+#endif
+}
+
+static const lv_font_t* get_font_small(void)
+{
+#if LV_FONT_MONTSERRAT_16
+    return &lv_font_montserrat_16;
+#else
+    return LV_FONT_DEFAULT;
+#endif
+}
+
+/* -- Periodic flush timer ------------------------------- */
+
+static void flush_timer_cb(lv_timer_t* timer)
+{
+    (void)timer;
+    memo_store_flush();
+}
+
+/* -- Reminder check timer ------------------------------ */
+
+static void remind_timer_cb(lv_timer_t* timer)
+{
+    memo_item_t items[MEMO_MAX_DISPLAY];
+    int count;
+    int i;
+    int64_t now;
+
+    (void)timer;
+    now = (int64_t)time(NULL);
+
+    count = memo_store_get_due_reminders(now, items, MEMO_MAX_DISPLAY);
+    for (i = 0; i < count; i++) {
+        memo_ui_show_notification("Reminder", items[i].content);
+        memo_store_mark_read(items[i].id);
+    }
+}
+
+/* -- Navigation dots ----------------------------------- */
+
+static void update_nav_dots(int active_idx)
+{
+    int i;
+
+    for (i = 0; i < 4; i++) {
+        if (g_nav_dots[i] == NULL) {
+            continue;
+        }
+        if (i == active_idx) {
+            lv_obj_set_style_bg_color(g_nav_dots[i],
+                lv_color_hex(UI_ACCENT_COLOR), 0);
+            lv_obj_set_size(g_nav_dots[i], 20, 8);
+        } else {
+            lv_obj_set_style_bg_color(g_nav_dots[i],
+                lv_color_hex(UI_TEXT_MUTED), 0);
+            lv_obj_set_size(g_nav_dots[i], 8, 8);
+        }
+    }
+}
+
+static void tileview_changed_cb(lv_event_t* e)
+{
+    lv_obj_t* tv = lv_event_get_target(e);
+    lv_obj_t* tile = lv_tileview_get_tile_active(tv);
+    int i;
+
+    for (i = 0; i < 4; i++) {
+        if (g_tiles[i] == tile) {
+            update_nav_dots(i);
+            break;
+        }
+    }
+}
+
+static void create_nav_bar(lv_obj_t* parent)
+{
+    int i;
+
+    g_nav_bar = lv_obj_create(parent);
+    lv_obj_set_size(g_nav_bar, g_screen_w, 30);
+    lv_obj_align(g_nav_bar, LV_ALIGN_BOTTOM_MID, 0, 0);
+    lv_obj_set_style_bg_color(g_nav_bar, lv_color_hex(UI_BG_COLOR), 0);
+    lv_obj_set_style_bg_opa(g_nav_bar, LV_OPA_COVER, 0);
+    lv_obj_set_style_border_width(g_nav_bar, 0, 0);
+    lv_obj_set_style_pad_all(g_nav_bar, 0, 0);
+    lv_obj_set_flex_flow(g_nav_bar, LV_FLEX_FLOW_ROW);
+    lv_obj_set_flex_align(g_nav_bar, LV_FLEX_ALIGN_CENTER,
+        LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_set_style_pad_column(g_nav_bar, 8, 0);
+    lv_obj_clear_flag(g_nav_bar, LV_OBJ_FLAG_SCROLLABLE);
+
+    for (i = 0; i < 4; i++) {
+        g_nav_dots[i] = lv_obj_create(g_nav_bar);
+        lv_obj_set_size(g_nav_dots[i], 8, 8);
+        lv_obj_set_style_radius(g_nav_dots[i], 4, 0);
+        lv_obj_set_style_bg_color(g_nav_dots[i],
+            lv_color_hex(UI_TEXT_MUTED), 0);
+        lv_obj_set_style_bg_opa(g_nav_dots[i], LV_OPA_COVER, 0);
+        lv_obj_set_style_border_width(g_nav_dots[i], 0, 0);
+        lv_obj_clear_flag(g_nav_dots[i], LV_OBJ_FLAG_SCROLLABLE);
+    }
+
+    update_nav_dots(0);
+}
+
+/* -- Page: Home ---------------------------------------- */
+
+static lv_obj_t* create_stat_card(lv_obj_t* parent,
+    const char* icon, const char* label, int count)
+{
+    char buf[32];
+    lv_obj_t* card;
+    lv_obj_t* lbl_icon;
+    lv_obj_t* lbl_count;
+    lv_obj_t* lbl_name;
+
+    card = lv_obj_create(parent);
+    lv_obj_set_size(card, (g_screen_w - 80) / 3, 100);
+    lv_obj_set_style_bg_color(card, lv_color_hex(UI_CARD_BG), 0);
+    lv_obj_set_style_bg_opa(card, LV_OPA_COVER, 0);
+    lv_obj_set_style_radius(card, 16, 0);
+    lv_obj_set_style_border_width(card, 0, 0);
+    lv_obj_set_style_pad_all(card, 16, 0);
+    lv_obj_set_flex_flow(card, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(card, LV_FLEX_ALIGN_CENTER,
+        LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_clear_flag(card, LV_OBJ_FLAG_SCROLLABLE);
+
+    lbl_icon = lv_label_create(card);
+    lv_label_set_text(lbl_icon, icon);
+    lv_obj_set_style_text_font(lbl_icon, get_font_large(), 0);
+    lv_obj_set_style_text_color(lbl_icon, lv_color_hex(UI_ACCENT_COLOR), 0);
+
+    snprintf(buf, sizeof(buf), "%d", count);
+    lbl_count = lv_label_create(card);
+    lv_label_set_text(lbl_count, buf);
+    lv_obj_set_style_text_font(lbl_count, get_font_large(), 0);
+    lv_obj_set_style_text_color(lbl_count, lv_color_white(), 0);
+
+    lbl_name = lv_label_create(card);
+    lv_label_set_text(lbl_name, label);
+    lv_obj_set_style_text_font(lbl_name, get_font_small(), 0);
+    lv_obj_set_style_text_color(lbl_name, lv_color_hex(UI_TEXT_MUTED), 0);
+
+    return lbl_count;
+}
+
+static void create_home_page(lv_obj_t* tile)
+{
+    lv_obj_t* title;
+    lv_obj_t* card_row;
+    int memo_cnt;
+    int todo_cnt;
+    int sched_cnt;
+
+    lv_obj_set_style_pad_all(tile, 30, 0);
+    lv_obj_set_flex_flow(tile, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(tile, LV_FLEX_ALIGN_START,
+        LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_set_style_pad_row(tile, 20, 0);
+    lv_obj_clear_flag(tile, LV_OBJ_FLAG_SCROLLABLE);
+
+    /* Title */
+
+    title = lv_label_create(tile);
+    lv_label_set_text(title, LV_SYMBOL_HOME "  Mini Memo");
+    lv_obj_set_style_text_font(title, get_font_large(), 0);
+    lv_obj_set_style_text_color(title, lv_color_white(), 0);
+
+    /* Stats row */
+
+    card_row = lv_obj_create(tile);
+    lv_obj_set_size(card_row, LV_PCT(100), LV_SIZE_CONTENT);
+    lv_obj_set_style_bg_opa(card_row, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(card_row, 0, 0);
+    lv_obj_set_style_pad_all(card_row, 0, 0);
+    lv_obj_set_flex_flow(card_row, LV_FLEX_FLOW_ROW);
+    lv_obj_set_flex_align(card_row, LV_FLEX_ALIGN_SPACE_EVENLY,
+        LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_clear_flag(card_row, LV_OBJ_FLAG_SCROLLABLE);
+
+    memo_cnt = memo_store_get_count(MEMO_TYPE_MEMO, true);
+    todo_cnt = memo_store_get_count(MEMO_TYPE_TODO, true);
+    sched_cnt = memo_store_get_count(MEMO_TYPE_SCHEDULE, true);
+
+    g_home_memo_count = create_stat_card(card_row,
+        LV_SYMBOL_FILE, "Memos", memo_cnt);
+    g_home_todo_count = create_stat_card(card_row,
+        LV_SYMBOL_LIST, "Todos", todo_cnt);
+    g_home_sched_count = create_stat_card(card_row,
+        LV_SYMBOL_BELL, "Schedule", sched_cnt);
+}
+
+/* -- Page: Voice --------------------------------------- */
+
+static lv_obj_t* g_voice_status_lbl;
+static lv_obj_t* g_ptt_btn;
+static bool g_recording;
+static lv_obj_t* g_review_list;
+static lv_timer_t* g_ptt_selftest_start_timer;
+static lv_timer_t* g_ptt_selftest_release_timer;
+static uint32_t g_ptt_selftest_hold_ms;
+
+static void refresh_review_list(void);
+static void ptt_selftest_release_cb(lv_timer_t* timer);
+
+static void ptt_selftest_start_cb(lv_timer_t* timer)
+{
+    lv_area_t coords;
+
+    if (timer != NULL) {
+        lv_timer_delete(timer);
+        g_ptt_selftest_start_timer = NULL;
+    }
+
+    if (g_tileview == NULL || g_tiles[MEMO_PAGE_VOICE] == NULL || g_ptt_btn == NULL) {
+        syslog(LOG_ERR, "PTT selftest: UI not ready\n");
+        return;
+    }
+
+    lv_tileview_set_tile(g_tileview, g_tiles[MEMO_PAGE_VOICE], LV_ANIM_OFF);
+    update_nav_dots(MEMO_PAGE_VOICE);
+    lv_obj_update_layout(lv_screen_active());
+    lv_obj_get_coords(g_ptt_btn, &coords);
+
+    syslog(LOG_INFO,
+        "PTT selftest: voice page ready, btn=(%ld,%ld)-(%ld,%ld), hold=%" PRIu32 "ms\n",
+        (long)coords.x1, (long)coords.y1, (long)coords.x2, (long)coords.y2,
+        g_ptt_selftest_hold_ms);
+
+    lv_obj_send_event(g_ptt_btn, LV_EVENT_PRESSED, NULL);
+
+    g_ptt_selftest_release_timer = lv_timer_create(ptt_selftest_release_cb,
+        g_ptt_selftest_hold_ms, NULL);
+    if (g_ptt_selftest_release_timer != NULL) {
+        lv_timer_set_repeat_count(g_ptt_selftest_release_timer, 1);
+    }
+}
+
+static void ptt_selftest_release_cb(lv_timer_t* timer)
+{
+    if (timer != NULL) {
+        lv_timer_delete(timer);
+        g_ptt_selftest_release_timer = NULL;
+    }
+
+    if (g_ptt_btn == NULL) {
+        syslog(LOG_ERR, "PTT selftest: button missing on release\n");
+        return;
+    }
+
+    syslog(LOG_INFO, "PTT selftest: releasing button\n");
+    lv_obj_send_event(g_ptt_btn, LV_EVENT_RELEASED, NULL);
+}
+
+/* Payload for marshalling classify results onto the LVGL thread. */
+
+typedef struct {
+    char status_text[64];
+    bool refresh;
+} classify_ui_t;
+
+/* Runs on the LVGL thread (via lv_async_call) where lv_* is safe. */
+
+static void classify_done_async_cb(void* p)
+{
+    classify_ui_t* u = (classify_ui_t*)p;
+
+    if (g_voice_status_lbl) {
+        lv_label_set_text(g_voice_status_lbl, u->status_text);
+    }
+
+    if (u->refresh) {
+        memo_ui_refresh_home();
+        refresh_review_list();
+    }
+
+    free(u);
+}
+
+static void on_classify_done(int status, const classify_result_t* result,
+    void* cookie)
+{
+    memo_item_t item;
+    classify_ui_t* u;
+    const char* type_name = "Memo";
+    (void)cookie;
+
+    /* This callback may run on the velaclaw SDK worker thread; lv_* is not
+     * thread-safe, so all UI work is deferred to the LVGL thread. */
+
+    u = malloc(sizeof(*u));
+    if (!u) {
+        syslog(LOG_ERR, "classify: ui payload alloc failed\n");
+        return;
+    }
+
+    if (status != 0 || !result) {
+        syslog(LOG_ERR, "classify failed status=%d\n", status);
+        strncpy(u->status_text, "Classification failed",
+            sizeof(u->status_text) - 1);
+        u->status_text[sizeof(u->status_text) - 1] = '\0';
+        u->refresh = false;
+        lv_async_call(classify_done_async_cb, u);
+        return;
+    }
+
+    /* Store the new memo (memo_store is thread-safe via internal mutex) */
+
+    memset(&item, 0, sizeof(item));
+    item.type = result->type;
+    strncpy(item.content, result->content, sizeof(item.content) - 1);
+    item.content[sizeof(item.content) - 1] = '\0';
+    item.timestamp = time(NULL);
+    item.remind_at = result->remind_at;
+    item.is_read = false;
+
+    memo_store_add(&item);
+
+    if (result->type == MEMO_TYPE_TODO) {
+        type_name = "Todo";
+    } else if (result->type == MEMO_TYPE_SCHEDULE) {
+        type_name = "Schedule";
+    }
+
+    snprintf(u->status_text, sizeof(u->status_text), "Saved as %s!",
+        type_name);
+    u->refresh = true;
+
+    lv_async_call(classify_done_async_cb, u);
+}
+
+static void ptt_pressed_cb(lv_event_t* e)
+{
+    (void)e;
+    int ret;
+
+    if (g_recording) {
+        return;
+    }
+
+    syslog(LOG_INFO, "PTT: pressed - start recording\n");
+    g_recording = true;
+
+    lv_obj_set_style_bg_color(g_ptt_btn, lv_color_hex(0xd53a3a), 0);
+    lv_label_set_text(g_voice_status_lbl, "Recording...");
+
+    ret = memo_voice_start();
+    if (ret < 0) {
+        syslog(LOG_ERR, "PTT: voice_start failed: %d\n", ret);
+        lv_label_set_text(g_voice_status_lbl, "Mic unavailable");
+        lv_obj_set_style_bg_color(g_ptt_btn,
+            lv_color_hex(UI_ACCENT_COLOR), 0);
+        g_recording = false;
+    }
+}
+
+static void ptt_released_cb(lv_event_t* e)
+{
+    (void)e;
+    char text_buf[512];
+    int ret;
+
+    if (!g_recording) {
+        return;
+    }
+
+    syslog(LOG_INFO, "PTT: released - stop recording\n");
+    g_recording = false;
+
+    lv_obj_set_style_bg_color(g_ptt_btn, lv_color_hex(UI_ACCENT_COLOR), 0);
+    lv_label_set_text(g_voice_status_lbl, "Recognizing...");
+
+    ret = memo_voice_stop(text_buf, sizeof(text_buf));
+    if (ret < 0 || text_buf[0] == '\0') {
+        lv_label_set_text(g_voice_status_lbl,
+            ret < 0 ? "ASR failed" : "No speech detected");
+        return;
+    }
+
+    /* Show transcribed text */
+
+    lv_label_set_text(g_voice_status_lbl, text_buf);
+
+    /* Classify and store */
+
+    memo_classify_async(text_buf, on_classify_done, NULL);
+}
+
+static void create_voice_page(lv_obj_t* tile)
+{
+    lv_obj_t* title;
+    lv_obj_t* ptt_lbl;
+
+    lv_obj_set_style_pad_all(tile, 30, 0);
+    lv_obj_set_flex_flow(tile, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(tile, LV_FLEX_ALIGN_CENTER,
+        LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_set_style_pad_row(tile, 20, 0);
+    lv_obj_clear_flag(tile, LV_OBJ_FLAG_SCROLLABLE);
+
+    title = lv_label_create(tile);
+    lv_label_set_text(title, LV_SYMBOL_AUDIO "  Voice Memo");
+    lv_obj_set_style_text_font(title, get_font_large(), 0);
+    lv_obj_set_style_text_color(title, lv_color_white(), 0);
+
+    /* PTT button (circular) */
+
+    g_ptt_btn = lv_obj_create(tile);
+    lv_obj_set_size(g_ptt_btn, 80, 80);
+    lv_obj_set_style_radius(g_ptt_btn, 40, 0);
+    lv_obj_set_style_bg_color(g_ptt_btn, lv_color_hex(UI_ACCENT_COLOR), 0);
+    lv_obj_set_style_bg_opa(g_ptt_btn, LV_OPA_COVER, 0);
+    lv_obj_set_style_border_width(g_ptt_btn, 0, 0);
+    lv_obj_clear_flag(g_ptt_btn, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_add_flag(g_ptt_btn, LV_OBJ_FLAG_CLICKABLE);
+
+    ptt_lbl = lv_label_create(g_ptt_btn);
+    lv_label_set_text(ptt_lbl, LV_SYMBOL_AUDIO);
+    lv_obj_set_style_text_font(ptt_lbl, get_font_large(), 0);
+    lv_obj_set_style_text_color(ptt_lbl, lv_color_white(), 0);
+    lv_obj_center(ptt_lbl);
+
+    /* PTT event handlers */
+
+    lv_obj_add_event_cb(g_ptt_btn, ptt_pressed_cb, LV_EVENT_PRESSED, NULL);
+    lv_obj_add_event_cb(g_ptt_btn, ptt_released_cb, LV_EVENT_RELEASED, NULL);
+
+    /* Status label */
+
+    g_voice_status_lbl = lv_label_create(tile);
+    lv_label_set_text(g_voice_status_lbl, "Hold button to record");
+    lv_obj_set_style_text_font(g_voice_status_lbl, get_font_small(), 0);
+    lv_obj_set_style_text_color(g_voice_status_lbl,
+        lv_color_hex(UI_TEXT_MUTED), 0);
+    lv_obj_set_width(g_voice_status_lbl, LV_PCT(90));
+    lv_label_set_long_mode(g_voice_status_lbl, LV_LABEL_LONG_WRAP);
+    lv_obj_set_style_text_align(g_voice_status_lbl, LV_TEXT_ALIGN_CENTER, 0);
+
+    g_recording = false;
+}
+
+/* -- Page: Review -------------------------------------- */
+
+static void review_item_swipe_cb(lv_event_t* e)
+{
+    lv_dir_t dir = lv_indev_get_gesture_dir(lv_indev_get_act());
+    lv_obj_t* row;
+    uint32_t id;
+
+    if (dir != LV_DIR_LEFT) {
+        return;
+    }
+
+    row = lv_event_get_current_target(e);
+    id = (uint32_t)(uintptr_t)lv_event_get_user_data(e);
+
+    memo_store_delete(id);
+
+    /* Animate row out then refresh */
+
+    lv_obj_add_flag(row, LV_OBJ_FLAG_HIDDEN);
+    refresh_review_list();
+    memo_ui_refresh_home();
+}
+
+static void refresh_review_list(void)
+{
+    memo_item_t items[MEMO_MAX_DISPLAY];
+    int count;
+    int i;
+
+    if (!g_review_list) {
+        return;
+    }
+
+    lv_obj_clean(g_review_list);
+
+    count = memo_store_get_recent(items, MEMO_MAX_DISPLAY);
+    if (count == 0) {
+        lv_obj_t* empty = lv_label_create(g_review_list);
+        lv_label_set_text(empty,
+            "No memos yet.\nSwipe to Voice page to add one.");
+        lv_obj_set_style_text_color(empty, lv_color_hex(UI_TEXT_MUTED), 0);
+        lv_obj_set_style_text_font(empty, get_font_small(), 0);
+        return;
+    }
+
+    /* Show items newest-first */
+
+    for (i = count - 1; i >= 0; i--) {
+        lv_obj_t* row = lv_obj_create(g_review_list);
+        lv_obj_t* type_lbl;
+        lv_obj_t* content_lbl;
+        const char* type_icon;
+
+        lv_obj_set_size(row, LV_PCT(100), LV_SIZE_CONTENT);
+        lv_obj_set_style_bg_opa(row, LV_OPA_TRANSP, 0);
+        lv_obj_set_style_border_width(row, 0, 0);
+        lv_obj_set_style_pad_all(row, 4, 0);
+        lv_obj_set_flex_flow(row, LV_FLEX_FLOW_ROW);
+        lv_obj_set_style_pad_column(row, 10, 0);
+        lv_obj_clear_flag(row, LV_OBJ_FLAG_SCROLLABLE);
+        lv_obj_add_flag(row, LV_OBJ_FLAG_CLICKABLE | LV_OBJ_FLAG_GESTURE_BUBBLE);
+
+        /* Swipe left to delete */
+
+        lv_obj_add_event_cb(row, review_item_swipe_cb,
+            LV_EVENT_GESTURE,
+            (void*)(uintptr_t)items[i].id);
+
+        switch (items[i].type) {
+        case MEMO_TYPE_TODO:
+            type_icon = LV_SYMBOL_LIST;
+            break;
+        case MEMO_TYPE_SCHEDULE:
+            type_icon = LV_SYMBOL_BELL;
+            break;
+        default:
+            type_icon = LV_SYMBOL_FILE;
+            break;
+        }
+
+        type_lbl = lv_label_create(row);
+        lv_label_set_text(type_lbl, type_icon);
+        lv_obj_set_style_text_color(type_lbl,
+            lv_color_hex(UI_ACCENT_COLOR), 0);
+
+        content_lbl = lv_label_create(row);
+        lv_label_set_text(content_lbl, items[i].content);
+        lv_obj_set_style_text_color(content_lbl, lv_color_white(), 0);
+        lv_obj_set_style_text_font(content_lbl, get_font_small(), 0);
+        lv_obj_set_width(content_lbl, LV_PCT(90));
+        lv_label_set_long_mode(content_lbl, LV_LABEL_LONG_DOT);
+    }
+}
+
+static void create_review_page(lv_obj_t* tile)
+{
+    lv_obj_t* title;
+    lv_obj_t* list;
+
+    lv_obj_set_style_pad_all(tile, 30, 0);
+    lv_obj_set_flex_flow(tile, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(tile, LV_FLEX_ALIGN_START,
+        LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_set_style_pad_row(tile, 10, 0);
+    lv_obj_clear_flag(tile, LV_OBJ_FLAG_SCROLLABLE);
+
+    title = lv_label_create(tile);
+    lv_label_set_text(title, LV_SYMBOL_LIST "  Review");
+    lv_obj_set_style_text_font(title, get_font_large(), 0);
+    lv_obj_set_style_text_color(title, lv_color_white(), 0);
+
+    /* Scrollable list of memos */
+
+    list = lv_obj_create(tile);
+    lv_obj_set_size(list, LV_PCT(100), g_screen_h - 130);
+    lv_obj_set_style_bg_color(list, lv_color_hex(UI_CARD_BG), 0);
+    lv_obj_set_style_bg_opa(list, LV_OPA_COVER, 0);
+    lv_obj_set_style_radius(list, 12, 0);
+    lv_obj_set_style_border_width(list, 0, 0);
+    lv_obj_set_style_pad_all(list, 16, 0);
+    lv_obj_set_flex_flow(list, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_style_pad_row(list, 8, 0);
+
+    g_review_list = list;
+    refresh_review_list();
+}
+
+/* -- Page: Settings ------------------------------------ */
+
+static void create_settings_page(lv_obj_t* tile)
+{
+    lv_obj_t* title;
+    lv_obj_t* info;
+
+    lv_obj_set_style_pad_all(tile, 30, 0);
+    lv_obj_set_flex_flow(tile, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(tile, LV_FLEX_ALIGN_START,
+        LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_set_style_pad_row(tile, 20, 0);
+    lv_obj_clear_flag(tile, LV_OBJ_FLAG_SCROLLABLE);
+
+    title = lv_label_create(tile);
+    lv_label_set_text(title, LV_SYMBOL_SETTINGS "  Settings");
+    lv_obj_set_style_text_font(title, get_font_large(), 0);
+    lv_obj_set_style_text_color(title, lv_color_white(), 0);
+
+    info = lv_label_create(tile);
+    lv_label_set_text(info,
+        "Review Interval: 4 hours\n\n"
+        "Storage: /data/mini_memo\n\n"
+        "Max Items: 100\n\n"
+        "Version: 1.0.0");
+    lv_obj_set_style_text_font(info, get_font_medium(), 0);
+    lv_obj_set_style_text_color(info, lv_color_hex(UI_TEXT_MUTED), 0);
+    lv_obj_set_style_text_line_space(info, 6, 0);
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int memo_ui_init(void)
+{
+    lv_obj_t* scr = lv_scr_act();
+    lv_display_t* disp = lv_display_get_default();
+
+    syslog(LOG_INFO, "memo_ui_init: creating 4-page UI\n");
+
+    /* Get actual display resolution */
+
+    if (disp) {
+        g_screen_w = lv_display_get_horizontal_resolution(disp);
+        g_screen_h = lv_display_get_vertical_resolution(disp);
+    }
+
+    syslog(LOG_INFO, "memo_ui_init: using res=%dx%d\n", g_screen_w, g_screen_h);
+
+    /* Dark background for screen */
+
+    lv_obj_set_style_bg_color(scr, lv_color_hex(UI_BG_COLOR), 0);
+    lv_obj_set_style_bg_opa(scr, LV_OPA_COVER, 0);
+
+    /* Create tileview (horizontal swipe between 4 pages) */
+
+    g_tileview = lv_tileview_create(scr);
+    lv_obj_set_size(g_tileview, g_screen_w, g_screen_h - 30);
+    lv_obj_align(g_tileview, LV_ALIGN_TOP_MID, 0, 0);
+    lv_obj_set_style_bg_opa(g_tileview, LV_OPA_TRANSP, 0);
+    lv_obj_set_scroll_snap_x(g_tileview, LV_SCROLL_SNAP_CENTER);
+
+    /* Add tiles: col 0-3, row 0 (horizontal only) */
+
+    g_tiles[MEMO_PAGE_HOME] = lv_tileview_add_tile(
+        g_tileview, 0, 0, LV_DIR_RIGHT);
+    g_tiles[MEMO_PAGE_VOICE] = lv_tileview_add_tile(
+        g_tileview, 1, 0, LV_DIR_LEFT | LV_DIR_RIGHT);
+    g_tiles[MEMO_PAGE_REVIEW] = lv_tileview_add_tile(
+        g_tileview, 2, 0, LV_DIR_LEFT | LV_DIR_RIGHT);
+    g_tiles[MEMO_PAGE_SETTINGS] = lv_tileview_add_tile(
+        g_tileview, 3, 0, LV_DIR_LEFT);
+
+    /* Populate each page */
+
+    create_home_page(g_tiles[MEMO_PAGE_HOME]);
+    create_voice_page(g_tiles[MEMO_PAGE_VOICE]);
+    create_review_page(g_tiles[MEMO_PAGE_REVIEW]);
+    create_settings_page(g_tiles[MEMO_PAGE_SETTINGS]);
+
+    /* Ensure tiles don't eat horizontal scroll - tileview owns it */
+
+    {
+        int i;
+        for (i = 0; i < 4; i++) {
+            lv_obj_add_flag(g_tiles[i], LV_OBJ_FLAG_SCROLL_CHAIN_HOR);
+            lv_obj_clear_flag(g_tiles[i], LV_OBJ_FLAG_SCROLL_ELASTIC);
+        }
+    }
+
+    /* Navigation dots at bottom */
+
+    create_nav_bar(scr);
+
+    /* Listen for tile changes to update dots */
+
+    lv_obj_add_event_cb(g_tileview, tileview_changed_cb,
+        LV_EVENT_VALUE_CHANGED, NULL);
+
+    /* Periodic flush timer (5 seconds) */
+
+    g_flush_timer = lv_timer_create(flush_timer_cb, 5000, NULL);
+
+    /* Reminder check timer (60 seconds) */
+
+    g_remind_timer = lv_timer_create(remind_timer_cb, 60000, NULL);
+
+    return 0;
+}
+
+void memo_ui_deinit(void)
+{
+    syslog(LOG_INFO, "memo_ui_deinit\n");
+    if (g_ptt_selftest_start_timer) {
+        lv_timer_delete(g_ptt_selftest_start_timer);
+        g_ptt_selftest_start_timer = NULL;
+    }
+    if (g_ptt_selftest_release_timer) {
+        lv_timer_delete(g_ptt_selftest_release_timer);
+        g_ptt_selftest_release_timer = NULL;
+    }
+    if (g_flush_timer) {
+        lv_timer_delete(g_flush_timer);
+        g_flush_timer = NULL;
+    }
+    if (g_remind_timer) {
+        lv_timer_delete(g_remind_timer);
+        g_remind_timer = NULL;
+    }
+    g_tileview = NULL;
+}
+
+void memo_ui_show_notification(const char* title, const char* body)
+{
+    lv_obj_t* mbox;
+
+    syslog(LOG_INFO, "memo_ui_show_notification: %s - %s\n", title, body);
+
+    mbox = lv_msgbox_create(NULL);
+    lv_msgbox_add_title(mbox, title);
+    lv_msgbox_add_text(mbox, body);
+    lv_msgbox_add_close_button(mbox);
+    lv_obj_center(mbox);
+}
+
+void memo_ui_refresh_home(void)
+{
+    char buf[16];
+    int count;
+
+    if (g_home_memo_count == NULL) {
+        return;
+    }
+
+    count = memo_store_get_count(MEMO_TYPE_MEMO, true);
+    snprintf(buf, sizeof(buf), "%d", count);
+    lv_label_set_text(g_home_memo_count, buf);
+
+    count = memo_store_get_count(MEMO_TYPE_TODO, true);
+    snprintf(buf, sizeof(buf), "%d", count);
+    lv_label_set_text(g_home_todo_count, buf);
+
+    count = memo_store_get_count(MEMO_TYPE_SCHEDULE, true);
+    snprintf(buf, sizeof(buf), "%d", count);
+    lv_label_set_text(g_home_sched_count, buf);
+}
+
+void memo_ui_navigate_to(int page_index)
+{
+    if (page_index < 0 || page_index > 3) {
+        return;
+    }
+
+    if (g_tileview == NULL || g_tiles[page_index] == NULL) {
+        return;
+    }
+
+    lv_tileview_set_tile(g_tileview, g_tiles[page_index], LV_ANIM_ON);
+    update_nav_dots(page_index);
+}
+
+int memo_ui_start_ptt_selftest(unsigned int hold_ms)
+{
+    if (g_ptt_btn == NULL || g_tileview == NULL || g_tiles[MEMO_PAGE_VOICE] == NULL) {
+        return -ENODEV;
+    }
+
+    if (g_ptt_selftest_start_timer != NULL || g_ptt_selftest_release_timer != NULL) {
+        return -EBUSY;
+    }
+
+    g_ptt_selftest_hold_ms = hold_ms == 0 ? 1000 : hold_ms;
+    g_ptt_selftest_start_timer = lv_timer_create(ptt_selftest_start_cb, 400, NULL);
+    if (g_ptt_selftest_start_timer == NULL) {
+        return -ENOMEM;
+    }
+
+    lv_timer_set_repeat_count(g_ptt_selftest_start_timer, 1);
+    syslog(LOG_INFO, "PTT selftest: scheduled\n");
+    return 0;
+}

--- a/mini_memo/mini_memo_ui.h
+++ b/mini_memo/mini_memo_ui.h
@@ -1,0 +1,40 @@
+/****************************************************************************
+ * Copyright (C) 2026 Xiaomi Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ****************************************************************************/
+
+#ifndef __MINI_MEMO_UI_H
+#define __MINI_MEMO_UI_H
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define MEMO_PAGE_HOME 0
+#define MEMO_PAGE_VOICE 1
+#define MEMO_PAGE_REVIEW 2
+#define MEMO_PAGE_SETTINGS 3
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+int memo_ui_init(void);
+void memo_ui_deinit(void);
+void memo_ui_show_notification(const char* title, const char* body);
+void memo_ui_refresh_home(void);
+void memo_ui_navigate_to(int page_index);
+int memo_ui_start_ptt_selftest(unsigned int hold_ms);
+
+#endif /* __MINI_MEMO_UI_H */


### PR DESCRIPTION
## Summary

Add **mini_memo**, a self-contained AI memory assistant LVGL demo for the Gemini-s1 board.

- Hold the PTT button to record a memo; on release the captured audio is classified (memo / todo / schedule) via the agent, with a local keyword fallback when the agent is unavailable.
- Memos are persisted with an atomic tmp+rename store.
- UI surfaces memos through Home, Voice, Review and Settings pages, plus a periodic reminder timer.
- Talks to the agent through the velaclaw local IPC client.

Gated behind `LVX_USE_DEMO_MINI_MEMO` in Kconfig.

> Depends on the local IPC client (`velaclaw/client.h`) added in the packages_ai_agent PR.

## Testing

- App builds as part of the board image with the demo enabled.

## Notes

- Only the 9 source files are included; build artifacts are excluded.
- Commit is signed off.