### PR TITLE
mini_memo: fix CMake build by adding ai_agent include paths

### DIFF
--- a/mini_memo/CMakeLists.txt
+++ b/mini_memo/CMakeLists.txt
@@ -22,11 +22,17 @@ if(CONFIG_LVX_USE_DEMO_MINI_MEMO)
   set(MAINSRC mini_memo_main.c)
   set(CSRCS mini_memo_core.c mini_memo_ui.c)
 
+  # AI Agent client SDK include paths (keep in sync with Makefile)
+  set(MINI_MEMO_INCDIRS
+      ${NUTTX_APPS_DIR}/packages/ai_agent/include
+      ${NUTTX_APPS_DIR}/packages/ai_agent/src)
+
   nuttx_add_application(
     NAME ${PROGNAME}
     PRIORITY ${PRIORITY}
     STACKSIZE ${STACKSIZE}
     MODULE ${MODULE}
     SRCS ${MAINSRC} ${CSRCS}
+    INCLUDE_DIRECTORIES ${MINI_MEMO_INCDIRS}
   )
 endif()

--- a/mini_memo/mini_memo_core.c
+++ b/mini_memo/mini_memo_core.c
@@ -328,8 +328,8 @@ int memo_store_load(void)
     }
 
     if (version_obj->valueint != MEMO_JSON_VERSION) {
-        syslog(LOG_WARNING, "%s: unsupported version %d\n",
-            MEMO_TAG, version_obj->valueint);
+        syslog(LOG_WARNING, "%s: unsupported version %lld\n",
+            MEMO_TAG, (long long)version_obj->valueint);
         cJSON_Delete(root);
         root = NULL;
         return 0;


### PR DESCRIPTION
## Summary

`mini_memo` fails to build with the CMake build system.

`mini_memo_core.c` includes `<velaclaw/client.h>` and links against the
ai_agent modules, and `Makefile` already carries the matching include paths:

```make
CFLAGS += ${INCDIR_PREFIX}$(APPDIR)/packages/ai_agent/include
CFLAGS += ${INCDIR_PREFIX}$(APPDIR)/packages/ai_agent/src
```

`CMakeLists.txt` had no equivalent, and `packages/ai_agent/CMakeLists.txt` does
not export its include directory to the `nuttx` target either, so the CMake
target had no way to resolve the header:

```
mini_memo_core.c:789:10: fatal error: velaclaw/client.h: No such file or directory
```

This PR passes the same two paths to `nuttx_add_application` via
`INCLUDE_DIRECTORIES`.

A second, independent build break shows up once the include paths are resolved.
`cJSON_int` is `long long` in this configuration, so the `%d` used for
`valueint` is rejected under `-Werror`:

```
mini_memo_core.c:331:55: error: format '%d' expects argument of type 'int',
  but argument 4 has type 'cJSON_int' {aka 'long long int'} [-Werror=format=]
```

Fixed with `%lld` plus an explicit `(long long)` cast, which is correct for both
variants of the conditionally-typed `cJSON_int`.

## Impact

- Build only. `mini_memo` now compiles under CMake as it already did under the
  Makefile build; the Makefile path is unchanged.
- No functional or runtime behaviour change. The only source edit is a `syslog`
  format specifier on an error path that triggers when a `memos.json` file
  carries an unsupported version number.
- No new dependency: `mini_memo`'s Kconfig already depends on
  `EXAMPLES_AI_AGENT_VELA || VELACLAW_DAEMON`, and the Makefile already used
  these include paths.

## Testing

Host: Ubuntu x86_64, `aarch64-none-elf-gcc` from `prebuilts/gcc/linux-x86_64`.
Target: `vela/goldfish-arm64-v8a-ap` (`CONFIG_BUILD_FLAT=y`,
`CONFIG_LVX_USE_DEMO_MINI_MEMO=y`, `CONFIG_EXAMPLES_AI_AGENT_VELA=y`).

Before, compiling `mini_memo_core.c` with the target's real compile command:

```
fatal error: velaclaw/client.h: No such file or directory     # without the -I paths
error: format '%d' expects argument of type 'int', ...         # with the -I paths
cc1: all warnings being treated as errors
```

After:

```
$ ninja apps/packages/demos/mini_memo/CMakeFiles/apps_mini_memo.dir/mini_memo_core.c.o \
        apps/packages/demos/mini_memo/CMakeFiles/apps_mini_memo.dir/mini_memo_ui.c.o \
        apps/packages/demos/mini_memo/CMakeFiles/apps_mini_memo.dir/mini_memo_main.c.o
[3/4] Building C object .../mini_memo_core.c.o
[4/4] Building C object .../mini_memo_ui.c.o
$ echo $?
0
```

All three `mini_memo` translation units build clean with `-Wall -Wshadow
-Wundef -Werror`.
